### PR TITLE
Iterators

### DIFF
--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -538,7 +538,7 @@ impl Bitcode {
         let mut reader = BitStreamReader::new();
         let mut visitor = CollectingVisitor::new();
         reader.read_block(
-            &mut Cursor::new(stream),
+            Cursor::new(stream),
             BitStreamReader::TOP_LEVEL_BLOCK_ID,
             2,
             &mut visitor,
@@ -563,7 +563,7 @@ impl Bitcode {
         }
         let mut reader = BitStreamReader::new();
         reader.read_block(
-            &mut Cursor::new(stream),
+            Cursor::new(stream),
             BitStreamReader::TOP_LEVEL_BLOCK_ID,
             2,
             visitor,

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -4,6 +4,7 @@ use std::{error, fmt};
 pub enum Error {
     BufferOverflow,
     VbrOverflow,
+    Alignment,
 }
 
 impl fmt::Display for Error {
@@ -11,39 +12,58 @@ impl fmt::Display for Error {
         f.write_str(match self {
             Self::BufferOverflow => "buffer overflow",
             Self::VbrOverflow => "vbr overflow",
+            Self::Alignment => "bad alignment",
         })
     }
 }
 
 impl error::Error for Error {}
 
-#[derive(Debug, Clone)]
-pub struct Cursor<'a> {
-    buffer: &'a [u8],
+#[derive(Clone)]
+pub struct Cursor<'input> {
+    buffer: &'input [u8],
     offset: usize,
 }
 
-impl<'a> Cursor<'a> {
-    pub fn new(buffer: &'a [u8]) -> Self {
+impl fmt::Debug for Cursor<'_> {
+    /// Debug-print only the accessible part of the internal buffer
+    #[cold]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let byte_offset = self.offset / 8;
+        let bit_offset = self.offset % 8;
+        let buffer = self.buffer.get(byte_offset..).unwrap_or_default();
+        f.debug_struct("Cursor")
+            .field("buffer", &buffer)
+            .field("offset", &bit_offset)
+            .finish()
+    }
+}
+
+impl<'input> Cursor<'input> {
+    #[must_use]
+    pub fn new(buffer: &'input [u8]) -> Self {
         Self { buffer, offset: 0 }
     }
 
+    #[must_use]
     pub fn is_at_end(&self) -> bool {
         self.offset >= (self.buffer.len() << 3)
     }
 
-    pub fn peek(&self, count: usize) -> Result<u64, Error> {
-        self.read_bits(count).ok_or(Error::BufferOverflow)
+    #[inline]
+    pub fn peek(&self, bits: u8) -> Result<u64, Error> {
+        self.read_bits(bits).ok_or(Error::BufferOverflow)
     }
 
-    pub fn read(&mut self, count: usize) -> Result<u64, Error> {
-        let res = self.peek(count)?;
-        self.offset += count;
+    #[inline]
+    pub fn read(&mut self, bits: u8) -> Result<u64, Error> {
+        let res = self.peek(bits)?;
+        self.offset += bits as usize;
         Ok(res)
     }
 
-    fn read_bits(&self, count: usize) -> Option<u64> {
-        let upper_bound = self.offset + count;
+    fn read_bits(&self, count: u8) -> Option<u64> {
+        let upper_bound = self.offset + count as usize;
         let top_byte_index = upper_bound >> 3;
         let mut res = 0;
         if upper_bound & 7 != 0 {
@@ -60,10 +80,12 @@ impl<'a> Cursor<'a> {
         Some(res)
     }
 
-    pub fn read_bytes(&mut self, count: usize) -> Result<&[u8], Error> {
-        assert_eq!(self.offset & 0b111, 0);
+    pub fn read_bytes(&mut self, length_bytes: usize) -> Result<&'input [u8], Error> {
+        if self.offset % 8 != 0 {
+            return Err(Error::Alignment);
+        }
         let byte_start = self.offset >> 3;
-        let byte_end = byte_start + count;
+        let byte_end = byte_start + length_bytes;
         let bytes = self
             .buffer
             .get(byte_start..byte_end)
@@ -73,7 +95,9 @@ impl<'a> Cursor<'a> {
     }
 
     pub fn skip_bytes(&mut self, count: usize) -> Result<(), Error> {
-        assert_eq!(self.offset & 0b111, 0);
+        if self.offset % 8 != 0 {
+            return Err(Error::Alignment);
+        }
         let byte_end = (self.offset >> 3) + count;
         if byte_end > self.buffer.len() {
             return Err(Error::BufferOverflow);
@@ -83,32 +107,34 @@ impl<'a> Cursor<'a> {
     }
 
     /// Create a cursor for `length_bytes`, and skip over `length_bytes`
-    pub(crate) fn take_slice(&mut self, length_bytes: usize) -> Result<Cursor<'_>, Error> {
-        assert_eq!(self.offset & 0b111, 0);
-        let byte_start = self.offset >> 3;
-        let byte_end = byte_start + length_bytes;
-        let buffer = self
-            .buffer
-            .get(byte_start..byte_end)
-            .ok_or(Error::BufferOverflow)?;
-        self.offset = byte_end << 3;
-        Ok(Cursor { buffer, offset: 0 })
+    /// Must be aligned to 32 bits.
+    pub(crate) fn take_slice(&mut self, length_bytes: usize) -> Result<Self, Error> {
+        if self.offset % 32 != 0 {
+            return Err(Error::Alignment);
+        }
+        Ok(Cursor {
+            buffer: self.read_bytes(length_bytes)?,
+            offset: 0,
+        })
     }
 
-    pub fn read_vbr(&mut self, width: usize) -> Result<u64, Error> {
-        if width < 1 {
+    /// Read a VBR number in `width`-wide encoding.
+    /// The number may be up to 64-bit long regardless of the `width`.
+    #[inline]
+    pub fn read_vbr(&mut self, width: u8) -> Result<u64, Error> {
+        if width < 1 || width > 64 {
             return Err(Error::VbrOverflow);
         }
-        let test_bit = (1 << (width - 1)) as u64;
+        let test_bit = 1u64 << (width - 1);
         let mask = test_bit - 1;
         let mut res = 0;
         let mut offset = 0;
-        let mut next;
         loop {
-            next = self.read(width)?;
+            let next = self.read(width)?;
             res |= (next & mask) << offset;
             offset += width - 1;
-            if offset > 64 {
+            // 64 may not be divisible by width
+            if offset > 63 + width {
                 return Err(Error::VbrOverflow);
             }
             if next & test_bit == 0 {
@@ -118,17 +144,97 @@ impl<'a> Cursor<'a> {
         Ok(res)
     }
 
-    pub fn advance(&mut self, align: usize) -> Result<(), Error> {
-        assert!(align > 0);
-        assert_eq!(align & (align - 1), 0);
-        if self.offset % align == 0 {
-            return Ok(());
-        }
-        let offset = (self.offset + align) & !(align - 1);
-        if offset > (self.buffer.len() << 3) {
-            return Err(Error::BufferOverflow);
-        }
-        self.offset = offset;
+    /// Skip bytes until a 32-bit boundary (no-op if already aligned)
+    pub fn align32(&mut self) -> Result<(), Error> {
+        let new_offset = if self.offset % 32 == 0 {
+            self.offset
+        } else {
+            (self.offset + 32) & !(32 - 1)
+        };
+        self.buffer = self
+            .buffer
+            .get((new_offset >> 3)..)
+            .ok_or(Error::BufferOverflow)?;
+        self.offset = 0;
         Ok(())
     }
+}
+
+#[test]
+fn test_cursor_bits() {
+    let mut c = Cursor::new(&[0b1000_0000]);
+    assert_eq!(0, c.peek(1).unwrap());
+    assert!(c.peek(9).is_err());
+    assert_eq!(0, c.peek(2).unwrap());
+    assert_eq!(0, c.peek(3).unwrap());
+    assert_eq!(0, c.peek(4).unwrap());
+    assert_eq!(0, c.peek(5).unwrap());
+    assert_eq!(0, c.peek(6).unwrap());
+    assert_eq!(0, c.peek(7).unwrap());
+    assert_eq!(0b1000_0000, c.peek(8).unwrap());
+    assert_eq!(0, c.read(6).unwrap());
+    assert_eq!(0b10, c.peek(2).unwrap());
+    assert_eq!(0, c.peek(1).unwrap());
+    assert_eq!(0, c.read(1).unwrap());
+    assert_eq!(0b1, c.peek(1).unwrap());
+    assert_eq!(0b1, c.read(1).unwrap());
+
+    let mut c = Cursor::new(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 0x55, 0x11, 0xff, 1, 127, 0x51]);
+    assert_eq!(0, c.peek(1).unwrap());
+    assert_eq!(0b1_0000_0000, c.peek(9).unwrap());
+    assert_eq!(0, c.peek(2).unwrap());
+    assert_eq!(0, c.peek(3).unwrap());
+    assert_eq!(0, c.peek(4).unwrap());
+    assert_eq!(0, c.peek(5).unwrap());
+    assert_eq!(0, c.peek(6).unwrap());
+    assert_eq!(0, c.peek(7).unwrap());
+    assert_eq!(0, c.peek(8).unwrap());
+    assert_eq!(0b1_0000_0000, c.peek(9).unwrap());
+
+    assert_eq!(0, c.peek(7).unwrap());
+    assert_eq!(0, c.read(0).unwrap());
+    assert_eq!(0, c.read(1).unwrap());
+    assert_eq!(0, c.read(2).unwrap());
+    assert_eq!(0, c.read(3).unwrap());
+    assert_eq!(4, c.read(4).unwrap());
+    assert_eq!(0, c.read(5).unwrap());
+    assert_eq!(4, c.read(6).unwrap());
+    assert_eq!(24, c.read(7).unwrap());
+    assert_eq!(64, c.read(8).unwrap());
+    assert_eq!(80, c.read(9).unwrap());
+    c.align32().unwrap();
+    let mut d = c.take_slice(6).unwrap();
+    assert_eq!(0x51, c.read(8).unwrap());
+    assert_eq!(0, d.read(0).unwrap());
+    assert_eq!(0, d.read(1).unwrap());
+    assert_eq!(0, d.read(2).unwrap());
+    assert_eq!(1, d.read(3).unwrap());
+    assert_eq!(4, d.read(4).unwrap());
+    assert_eq!(21, d.read(5).unwrap());
+    assert_eq!(34, d.read(6).unwrap());
+    assert_eq!(120, d.read(7).unwrap());
+    assert_eq!(31, d.read(8).unwrap());
+    assert!(d.read(63).is_err());
+    assert_eq!(496, d.read(9).unwrap());
+    assert_eq!(0, d.read(0).unwrap());
+    assert_eq!(1, d.read(1).unwrap());
+    assert!(d.align32().is_err());
+    assert_eq!(1, d.read(2).unwrap());
+    assert!(d.align32().is_err());
+    assert!(d.read(1).is_err());
+}
+
+#[test]
+fn test_cursor_bytes() {
+    let mut c = Cursor::new(&[0, 1, 2, 3, 4, 5, 6, 7, 8]);
+    c.align32().unwrap();
+    assert_eq!(0x0100, c.peek(16).unwrap());
+    assert_eq!(0x020100, c.peek(24).unwrap());
+    assert_eq!(0x03020100, c.peek(32).unwrap());
+    assert_eq!(0x0100, c.read(16).unwrap());
+    assert_eq!(0x02, c.read(8).unwrap());
+    assert_eq!([3, 4, 5, 6], c.read_bytes(4).unwrap());
+    c.skip_bytes(1).unwrap();
+    assert!(c.read_bytes(2).is_err());
+    assert_eq!([8], c.read_bytes(1).unwrap());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,5 +11,6 @@ pub mod read;
 pub mod visitor;
 
 pub use self::bitcode::Bitcode;
+pub use self::bits::Cursor;
 pub use self::read::BitStreamReader;
 pub use self::visitor::BitStreamVisitor;

--- a/src/read.rs
+++ b/src/read.rs
@@ -234,7 +234,9 @@ impl BitStreamReader {
                         BlockInfoCode::BlockName => {
                             let block_id = current_block_id.ok_or(Error::MissingSetBid)?;
                             let block_info = self.block_info.entry(block_id).or_default();
-                            block_info.name = record.string()?;
+                            if let Ok(name) = String::from_utf8(record.string()?) {
+                                block_info.name = name;
+                            }
                         }
                         BlockInfoCode::SetRecordName => {
                             let block_id = current_block_id.ok_or(Error::MissingSetBid)?;
@@ -242,8 +244,9 @@ impl BitStreamReader {
                                 .u64()
                                 .map_err(|_| Error::InvalidBlockInfoRecord(record.id))?;
                             let block_info = self.block_info.entry(block_id).or_default();
-                            let name = record.string()?;
-                            block_info.record_names.insert(record_id, name);
+                            if let Ok(name) = String::from_utf8(record.string()?) {
+                                block_info.record_names.insert(record_id, name);
+                            }
                         }
                     }
                 }

--- a/tests/test_bitcode_reader.rs
+++ b/tests/test_bitcode_reader.rs
@@ -58,7 +58,7 @@ fn test_bitstream_reader() {
                 match payload {
                     Payload::Array(ele) => format!("array({} elements)", ele.len()),
                     Payload::Blob(blob) => format!("blob({} bytes)", blob.len()),
-                    Payload::Char6String(s) => s.to_string(),
+                    Payload::Char6String(s) => s,
                 }
             } else {
                 "none".to_string()


### PR DESCRIPTION
The commits have smaller changes when viewed individually, especially if you ignore whitespace.

I've added an imperative iterator for blocks and records, replacing the visitor. This is how LLVM implements it, and as a side effect it depends on function-local state like last const type, next struct name, current instruction id. The visitor pattern requires storing these in the visitor to keep state across calls to visiting record, which is much more harder to track. Blocks are also nested, so parsing of the global constants block and function-local constants needs slightly different logic. This is easy to do when parsing function block is a loop, less so when it's a callback.

I've also added record iterator that reads data as requested, instead of reading and allocating it all up front. This makes reading of strings and smaller data types a bit nicer. A single `Vec` for all fields is inconvenient when parsing data into struct fields, and even IR instructions that have arrays of operands, have some fields before the array and need a different item type.

LLVM is playing loose with abbreviation IDs for records. Sometimes it means to include an "array" at the end of an instruction, but it's not always an abbreviation record. Having fixed split between fields and payload made that cumbersome. In the record iterator, the remaining unread fields can be collected into an array.

LLVM arrays can't be nested. I've split Operand into Scalar and Payload types, which made it simpler to handle the fields without as many checks of operand types. It made operands `Copy`, which helps too.