### PR TITLE
The unfinished rest

### DIFF
--- a/examples/llvm_bca.rs
+++ b/examples/llvm_bca.rs
@@ -1,0 +1,1080 @@
+#![allow(non_camel_case_types)]
+use llvm_bitcode::bitcode::Signature;
+use llvm_bitcode::read::BlockItem;
+use llvm_bitcode::read::BlockIter;
+use llvm_bitcode::read::Error;
+use llvm_bitcode::BitStreamReader;
+use num_enum::TryFromPrimitive;
+
+fn main() {
+    let path = std::env::args()
+        .nth(1)
+        .expect("Provide file path to a .bc file");
+    let file = std::fs::read(&path).unwrap();
+
+    let mut reader = BitStreamReader::new();
+    let (sig, bitcode) = Signature::parse(&file).unwrap();
+
+    println!(
+        "<BITCODE_WRAPPER_HEADER Magic=0x{:08x} Version=0x{:08x} Offset=0x{:08x} Size=0x{:08x} CPUType=0x{:08x}/>",
+        sig.magic, sig.version, sig.offset, sig.size, sig.cpu_type
+    );
+    iter_block(reader.iter_bitcode(bitcode), 0).unwrap();
+}
+
+fn iter_block(mut block: BlockIter, depth: usize) -> Result<(), Error> {
+    let outer_block_id = block.id;
+    while let Some(b) = block.next()? {
+        match b {
+            BlockItem::Block(b) => {
+                let tag_name = block_tag_name(b.id as _);
+                println!(
+                    "{:indent$}<{tag_name} NumWords={nw} BlockCodeSize={ab}>",
+                    "",
+                    nw = b.debug_data_len().unwrap_or(0) / 4,
+                    ab = b.debug_abbrev_width(),
+                    indent = depth * 2
+                );
+                iter_block(b, depth + 1)?;
+                println!("{:indent$}</{tag_name}>", "", indent = depth * 2);
+            }
+            BlockItem::Record(mut r) => {
+                let tag_name = record_tag_name(outer_block_id as _, r.id as _);
+                print!("{:indent$}<{tag_name}", "", indent = depth * 2);
+                if let Some(a) = r.debug_abbrev_id() {
+                    print!(" abbrevid={a}");
+                }
+                let fields = r
+                    .by_ref()
+                    .map(|f| f.map(|f| f as i64))
+                    .collect::<Result<Vec<_>, _>>()?;
+                for (i, &op) in fields.iter().enumerate() {
+                    print!(" op{i}={op}");
+                }
+                let payload: Result<_, _> = r.payload();
+                match payload {
+                    Ok(Some(llvm_bitcode::bitcode::Payload::Array(a))) => {
+                        for (i, op) in a.iter().enumerate() {
+                            print!(" op{}={op}", i + fields.len());
+                        }
+                        if !a.is_empty() && a.iter().all(|&c| (c as u8) >= 0x20 && (c as u8) < 0x7F)
+                        {
+                            // lol bug in the original
+                            let s: String = a.iter().map(|&c| c as u8 as char).collect();
+                            println!("/> record string = '{s}'");
+                        } else {
+                            println!("/>");
+                        }
+                    }
+                    Ok(Some(llvm_bitcode::bitcode::Payload::Char6String(s))) => {
+                        for (i, op) in s.chars().enumerate() {
+                            print!(" op{}={}", i + fields.len(), op as u32);
+                        }
+                        if s.is_empty() {
+                            println!("/>");
+                        } else {
+                            println!("/> record string = '{s}'");
+                        }
+                    }
+                    Ok(None) => {
+                        if r.debug_abbrev_id().is_some()
+                            && fields.len() > 1
+                            && fields.iter().skip(1).all(|&c| (0x20..0x7F).contains(&c))
+                        {
+                            let s: String =
+                                fields.iter().skip(1).map(|&c| c as u8 as char).collect();
+                            println!("/> record string = '{s}'");
+                        } else {
+                            println!("/>");
+                        }
+                    }
+                    Ok(Some(llvm_bitcode::bitcode::Payload::Blob(b))) => {
+                        if b.len() < 10000 && b.iter().all(|&c| (0x20..0x7F).contains(&c)) {
+                            println!("/> blob data = {}", String::from_utf8_lossy(&b));
+                        } else {
+                            print!("/> blob data = ");
+                            if b.len() > 50 {
+                                print!("unprintable, {} bytes.", b.len());
+                            } else {
+                                print!("'");
+                                for b in b {
+                                    print!("{b:02x}");
+                                }
+                                print!("'");
+                            }
+                            println!();
+                        }
+                    }
+                    Err(err) => print!("/> payload_err={err}"),
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn block_tag_name(id: u32) -> &'static str {
+    use Blocks::*;
+    match Blocks::try_from(id).unwrap() {
+        MODULE_BLOCK_ID => "MODULE_BLOCK",
+        PARAMATTR_BLOCK_ID => "PARAMATTR_BLOCK",
+        PARAMATTR_GROUP_BLOCK_ID => "PARAMATTR_GROUP_BLOCK_ID",
+        CONSTANTS_BLOCK_ID => "CONSTANTS_BLOCK",
+        FUNCTION_BLOCK_ID => "FUNCTION_BLOCK",
+        IDENTIFICATION_BLOCK_ID => "IDENTIFICATION_BLOCK_ID",
+        VALUE_SYMTAB_BLOCK_ID => "VALUE_SYMTAB",
+        METADATA_BLOCK_ID => "METADATA_BLOCK",
+        METADATA_ATTACHMENT_ID => "METADATA_ATTACHMENT_BLOCK",
+        TYPE_BLOCK_ID_NEW => "TYPE_BLOCK_ID",
+        USELIST_BLOCK_ID => "USELIST_BLOCK",
+        MODULE_STRTAB_BLOCK_ID => "MODULE_STRTAB_BLOCK",
+        GLOBALVAL_SUMMARY_BLOCK_ID => "GLOBALVAL_SUMMARY_BLOCK",
+        OPERAND_BUNDLE_TAGS_BLOCK_ID => "OPERAND_BUNDLE_TAGS_BLOCK",
+        METADATA_KIND_BLOCK_ID => "METADATA_KIND_BLOCK",
+        STRTAB_BLOCK_ID => "STRTAB_BLOCK",
+        FULL_LTO_GLOBALVAL_SUMMARY_BLOCK_ID => "FULL_LTO_GLOBALVAL_SUMMARY_BLOCK",
+        SYMTAB_BLOCK_ID => "SYMTAB_BLOCK",
+        SYNC_SCOPE_NAMES_BLOCK_ID => "UnknownBlock26", //"SYNC_SCOPE_NAMES_BLOCK",
+    }
+}
+
+fn record_tag_name(block: u32, record: u32) -> &'static str {
+    match Blocks::try_from(block).unwrap() {
+        Blocks::MODULE_BLOCK_ID => match ModuleCodes::try_from(record).unwrap() {
+            ModuleCodes::MODULE_CODE_VERSION => "VERSION",
+            ModuleCodes::MODULE_CODE_TRIPLE => "TRIPLE",
+            ModuleCodes::MODULE_CODE_DATALAYOUT => "DATALAYOUT",
+            ModuleCodes::MODULE_CODE_ASM => "ASM",
+            ModuleCodes::MODULE_CODE_SECTIONNAME => "SECTIONNAME",
+            ModuleCodes::MODULE_CODE_DEPLIB => "DEPLIB",
+            ModuleCodes::MODULE_CODE_GLOBALVAR => "GLOBALVAR",
+            ModuleCodes::MODULE_CODE_FUNCTION => "FUNCTION",
+            ModuleCodes::MODULE_CODE_ALIAS => "ALIAS",
+            ModuleCodes::MODULE_CODE_GCNAME => "GCNAME",
+            ModuleCodes::MODULE_CODE_COMDAT => "COMDAT",
+            ModuleCodes::MODULE_CODE_VSTOFFSET => "VSTOFFSET",
+            ModuleCodes::MODULE_CODE_METADATA_VALUES_UNUSED => "METADATA_VALUES_UNUSED",
+            ModuleCodes::MODULE_CODE_SOURCE_FILENAME => "SOURCE_FILENAME",
+            ModuleCodes::MODULE_CODE_HASH => "HASH",
+            ModuleCodes::MODULE_CODE_ALIAS_OLD | ModuleCodes::MODULE_CODE_IFUNC => todo!(),
+        },
+        Blocks::IDENTIFICATION_BLOCK_ID => match IdentificationCodes::try_from(record).unwrap() {
+            IdentificationCodes::IDENTIFICATION_CODE_STRING => "STRING",
+            IdentificationCodes::IDENTIFICATION_CODE_EPOCH => "EPOCH",
+        },
+        crate::Blocks::PARAMATTR_GROUP_BLOCK_ID | crate::Blocks::PARAMATTR_BLOCK_ID => {
+            match AttributeCodes::try_from(record).unwrap() {
+                AttributeCodes::PARAMATTR_CODE_ENTRY_OLD => "ENTRY_OLD",
+                AttributeCodes::PARAMATTR_CODE_ENTRY => "ENTRY",
+                AttributeCodes::PARAMATTR_GRP_CODE_ENTRY => "ENTRY",
+            }
+        }
+        Blocks::TYPE_BLOCK_ID_NEW => match TypeCodes::try_from(record).unwrap() {
+            TypeCodes::TYPE_CODE_NUMENTRY => "NUMENTRY",
+            TypeCodes::TYPE_CODE_VOID => "VOID",
+            TypeCodes::TYPE_CODE_FLOAT => "FLOAT",
+            TypeCodes::TYPE_CODE_DOUBLE => "DOUBLE",
+            TypeCodes::TYPE_CODE_LABEL => "LABEL",
+            TypeCodes::TYPE_CODE_OPAQUE => "OPAQUE",
+            TypeCodes::TYPE_CODE_INTEGER => "INTEGER",
+            TypeCodes::TYPE_CODE_POINTER => "POINTER",
+            TypeCodes::TYPE_CODE_HALF => "HALF",
+            TypeCodes::TYPE_CODE_ARRAY => "ARRAY",
+            TypeCodes::TYPE_CODE_VECTOR => "VECTOR",
+            TypeCodes::TYPE_CODE_X86_FP80 => "X86_FP80",
+            TypeCodes::TYPE_CODE_FP128 => "FP128",
+            TypeCodes::TYPE_CODE_PPC_FP128 => "PPC_FP128",
+            TypeCodes::TYPE_CODE_METADATA => "METADATA",
+            TypeCodes::TYPE_CODE_X86_MMX => "X86_MMX",
+            TypeCodes::TYPE_CODE_STRUCT_ANON => "STRUCT_ANON",
+            TypeCodes::TYPE_CODE_STRUCT_NAME => "STRUCT_NAME",
+            TypeCodes::TYPE_CODE_STRUCT_NAMED => "STRUCT_NAMED",
+            TypeCodes::TYPE_CODE_FUNCTION => "FUNCTION",
+            TypeCodes::TYPE_CODE_TOKEN => "TOKEN",
+            TypeCodes::TYPE_CODE_BFLOAT => "BFLOAT",
+            TypeCodes::TYPE_CODE_FUNCTION_OLD => "FUNCTION_OLD",
+            TypeCodes::TYPE_CODE_X86_AMX => "X86_AMX",
+            TypeCodes::TYPE_CODE_OPAQUE_POINTER => "UnknownCode25", //"OPAQUE_POINTER",
+            TypeCodes::TYPE_CODE_TARGET_TYPE => "TARGET_TYPE",
+        },
+        Blocks::CONSTANTS_BLOCK_ID => match ConstantsCodes::try_from(record).unwrap() {
+            ConstantsCodes::CST_CODE_SETTYPE => "SETTYPE",
+            ConstantsCodes::CST_CODE_NULL => "NULL",
+            ConstantsCodes::CST_CODE_UNDEF => "UNDEF",
+            ConstantsCodes::CST_CODE_INTEGER => "INTEGER",
+            ConstantsCodes::CST_CODE_WIDE_INTEGER => "WIDE_INTEGER",
+            ConstantsCodes::CST_CODE_FLOAT => "FLOAT",
+            ConstantsCodes::CST_CODE_AGGREGATE => "AGGREGATE",
+            ConstantsCodes::CST_CODE_STRING => "STRING",
+            ConstantsCodes::CST_CODE_CSTRING => "CSTRING",
+            ConstantsCodes::CST_CODE_CE_BINOP => "CE_BINOP",
+            ConstantsCodes::CST_CODE_CE_CAST => "CE_CAST",
+            ConstantsCodes::CST_CODE_CE_GEP => "CE_GEP",
+            ConstantsCodes::CST_CODE_CE_INBOUNDS_GEP => "CE_INBOUNDS_GEP",
+            ConstantsCodes::CST_CODE_CE_SELECT => "CE_SELECT",
+            ConstantsCodes::CST_CODE_CE_EXTRACTELT => "CE_EXTRACTELT",
+            ConstantsCodes::CST_CODE_CE_INSERTELT => "CE_INSERTELT",
+            ConstantsCodes::CST_CODE_CE_SHUFFLEVEC => "CE_SHUFFLEVEC",
+            ConstantsCodes::CST_CODE_CE_CMP => "CE_CMP",
+            ConstantsCodes::CST_CODE_INLINEASM => "INLINEASM",
+            ConstantsCodes::CST_CODE_CE_SHUFVEC_EX => "CE_SHUFVEC_EX",
+            ConstantsCodes::CST_CODE_CE_UNOP => "CE_UNOP",
+            ConstantsCodes::CST_CODE_DSO_LOCAL_EQUIVALENT => "DSO_LOCAL_EQUIVALENT",
+            ConstantsCodes::CST_CODE_NO_CFI_VALUE => "NO_CFI_VALUE",
+            ConstantsCodes::CST_CODE_PTRAUTH => "PTRAUTH",
+            ConstantsCodes::CST_CODE_BLOCKADDRESS => "BLOCKADDRESS",
+            ConstantsCodes::CST_CODE_DATA => "DATA",
+            ConstantsCodes::CST_CODE_CE_GEP_OLD => "CE_GEP_OLD",
+            ConstantsCodes::CST_CODE_INLINEASM_OLD => "INLINEASM_OLD",
+            ConstantsCodes::CST_CODE_INLINEASM_OLD2 => "INLINEASM_OLD2",
+            ConstantsCodes::CST_CODE_CE_GEP_WITH_INRANGE_INDEX_OLD => {
+                "CE_GEP_WITH_INRANGE_INDEX_OLD"
+            }
+            ConstantsCodes::CST_CODE_POISON => "UnknownCode26", //"POISON",
+            ConstantsCodes::CST_CODE_INLINEASM_OLD3 => "INLINEASM_OLD3",
+            ConstantsCodes::CST_CODE_CE_GEP_WITH_INRANGE => "CE_GEP_WITH_INRANGE",
+        },
+        Blocks::FUNCTION_BLOCK_ID => match FunctionCodes::try_from(record).unwrap() {
+            FunctionCodes::FUNC_CODE_DECLAREBLOCKS => "DECLAREBLOCKS",
+            FunctionCodes::FUNC_CODE_INST_BINOP => "INST_BINOP",
+            FunctionCodes::FUNC_CODE_INST_CAST => "INST_CAST",
+            FunctionCodes::FUNC_CODE_INST_GEP_OLD => "INST_GEP_OLD",
+            FunctionCodes::FUNC_CODE_INST_INBOUNDS_GEP_OLD => "INST_INBOUNDS_GEP_OLD",
+            FunctionCodes::FUNC_CODE_INST_SELECT => "INST_SELECT",
+            FunctionCodes::FUNC_CODE_INST_EXTRACTELT => "INST_EXTRACTELT",
+            FunctionCodes::FUNC_CODE_INST_INSERTELT => "INST_INSERTELT",
+            FunctionCodes::FUNC_CODE_INST_SHUFFLEVEC => "INST_SHUFFLEVEC",
+            FunctionCodes::FUNC_CODE_INST_CMP => "INST_CMP",
+            FunctionCodes::FUNC_CODE_INST_RET => "INST_RET",
+            FunctionCodes::FUNC_CODE_INST_BR => "INST_BR",
+            FunctionCodes::FUNC_CODE_INST_SWITCH => "INST_SWITCH",
+            FunctionCodes::FUNC_CODE_INST_INVOKE => "INST_INVOKE",
+            FunctionCodes::FUNC_CODE_INST_UNOP => "INST_UNOP",
+            FunctionCodes::FUNC_CODE_INST_UNREACHABLE => "INST_UNREACHABLE",
+            FunctionCodes::FUNC_CODE_INST_CLEANUPRET => "INST_CLEANUPRET",
+            FunctionCodes::FUNC_CODE_INST_CATCHRET => "INST_CATCHRET",
+            FunctionCodes::FUNC_CODE_INST_CATCHPAD => "INST_CATCHPAD",
+            FunctionCodes::FUNC_CODE_INST_PHI => "INST_PHI",
+            FunctionCodes::FUNC_CODE_INST_ALLOCA => "INST_ALLOCA",
+            FunctionCodes::FUNC_CODE_INST_LOAD => "INST_LOAD",
+            FunctionCodes::FUNC_CODE_INST_VAARG => "INST_VAARG",
+            FunctionCodes::FUNC_CODE_INST_STORE => "INST_STORE",
+            FunctionCodes::FUNC_CODE_INST_EXTRACTVAL => "INST_EXTRACTVAL",
+            FunctionCodes::FUNC_CODE_INST_INSERTVAL => "INST_INSERTVAL",
+            FunctionCodes::FUNC_CODE_INST_CMP2 => "INST_CMP2",
+            FunctionCodes::FUNC_CODE_INST_VSELECT => "INST_VSELECT",
+            FunctionCodes::FUNC_CODE_DEBUG_LOC_AGAIN => "DEBUG_LOC_AGAIN",
+            FunctionCodes::FUNC_CODE_INST_CALL => "INST_CALL",
+            FunctionCodes::FUNC_CODE_DEBUG_LOC => "DEBUG_LOC",
+            FunctionCodes::FUNC_CODE_INST_GEP => "INST_GEP",
+            FunctionCodes::FUNC_CODE_OPERAND_BUNDLE => "OPERAND_BUNDLE",
+            FunctionCodes::FUNC_CODE_INST_FENCE => "INST_FENCE",
+            FunctionCodes::FUNC_CODE_INST_ATOMICRMW => "INST_ATOMICRMW",
+            FunctionCodes::FUNC_CODE_INST_LOADATOMIC => "INST_LOADATOMIC",
+            FunctionCodes::FUNC_CODE_INST_STOREATOMIC => "INST_STOREATOMIC",
+            FunctionCodes::FUNC_CODE_INST_CMPXCHG => "INST_CMPXCHG",
+            FunctionCodes::FUNC_CODE_INST_CALLBR => "INST_CALLBR",
+            FunctionCodes::FUNC_CODE_BLOCKADDR_USERS => "BLOCKADDR_USERS",
+            FunctionCodes::FUNC_CODE_DEBUG_RECORD_DECLARE => "DEBUG_RECORD_DECLARE",
+            FunctionCodes::FUNC_CODE_DEBUG_RECORD_VALUE => "DEBUG_RECORD_VALUE",
+            FunctionCodes::FUNC_CODE_DEBUG_RECORD_ASSIGN => "DEBUG_RECORD_ASSIGN",
+            FunctionCodes::FUNC_CODE_DEBUG_RECORD_VALUE_SIMPLE => "DEBUG_RECORD_VALUE_SIMPLE",
+            FunctionCodes::FUNC_CODE_DEBUG_RECORD_LABEL => "DEBUG_RECORD_LABEL",
+
+            FunctionCodes::FUNC_CODE_INST_STORE_OLD => "INST_STORE_OLD",
+            FunctionCodes::FUNC_CODE_INST_INDIRECTBR => "INST_INDIRECTBR",
+            FunctionCodes::FUNC_CODE_INST_CMPXCHG_OLD => "INST_CMPXCHG_OLD",
+            FunctionCodes::FUNC_CODE_INST_ATOMICRMW_OLD => "INST_ATOMICRMW_OLD",
+            FunctionCodes::FUNC_CODE_INST_RESUME => "UnknownCode39", //"INST_RESUME",
+            FunctionCodes::FUNC_CODE_INST_LANDINGPAD_OLD => "INST_LANDINGPAD_OLD",
+            FunctionCodes::FUNC_CODE_INST_STOREATOMIC_OLD => "INST_STOREATOMIC_OLD",
+            FunctionCodes::FUNC_CODE_INST_LANDINGPAD => "UnknownCode47", //"INST_LANDINGPAD",
+            FunctionCodes::FUNC_CODE_INST_CLEANUPPAD => "INST_CLEANUPPAD",
+            FunctionCodes::FUNC_CODE_INST_CATCHSWITCH => "INST_CATCHSWITCH",
+            FunctionCodes::FUNC_CODE_INST_FREEZE => "INST_FREEZE",
+        },
+        Blocks::VALUE_SYMTAB_BLOCK_ID => match ValueSymtabCodes::try_from(record).unwrap() {
+            ValueSymtabCodes::VST_CODE_ENTRY => "ENTRY",
+            ValueSymtabCodes::VST_CODE_BBENTRY => "BBENTRY",
+            ValueSymtabCodes::VST_CODE_FNENTRY => "FNENTRY",
+            ValueSymtabCodes::VST_CODE_COMBINED_ENTRY => "COMBINED_ENTRY",
+        },
+        Blocks::MODULE_STRTAB_BLOCK_ID => match ModulePathSymtabCodes::try_from(record).unwrap() {
+            ModulePathSymtabCodes::MST_CODE_ENTRY => "ENTRY",
+            ModulePathSymtabCodes::MST_CODE_HASH => "HASH",
+        },
+        crate::Blocks::GLOBALVAL_SUMMARY_BLOCK_ID
+        | crate::Blocks::FULL_LTO_GLOBALVAL_SUMMARY_BLOCK_ID => {
+            match GlobalValueSummarySymtabCodes::try_from(record).unwrap() {
+                GlobalValueSummarySymtabCodes::FS_PERMODULE => "PERMODULE",
+                GlobalValueSummarySymtabCodes::FS_PERMODULE_PROFILE => "PERMODULE_PROFILE",
+                GlobalValueSummarySymtabCodes::FS_PERMODULE_RELBF => "PERMODULE_RELBF",
+                GlobalValueSummarySymtabCodes::FS_PERMODULE_GLOBALVAR_INIT_REFS => {
+                    "PERMODULE_GLOBALVAR_INIT_REFS"
+                }
+                GlobalValueSummarySymtabCodes::FS_PERMODULE_VTABLE_GLOBALVAR_INIT_REFS => {
+                    "PERMODULE_VTABLE_GLOBALVAR_INIT_REFS"
+                }
+                GlobalValueSummarySymtabCodes::FS_COMBINED => "COMBINED",
+                GlobalValueSummarySymtabCodes::FS_COMBINED_PROFILE => "COMBINED_PROFILE",
+                GlobalValueSummarySymtabCodes::FS_COMBINED_GLOBALVAR_INIT_REFS => {
+                    "COMBINED_GLOBALVAR_INIT_REFS"
+                }
+                GlobalValueSummarySymtabCodes::FS_ALIAS => "ALIAS",
+                GlobalValueSummarySymtabCodes::FS_COMBINED_ALIAS => "COMBINED_ALIAS",
+                GlobalValueSummarySymtabCodes::FS_COMBINED_ORIGINAL_NAME => {
+                    "COMBINED_ORIGINAL_NAME"
+                }
+                GlobalValueSummarySymtabCodes::FS_VERSION => "VERSION",
+                GlobalValueSummarySymtabCodes::FS_FLAGS => "FLAGS",
+                GlobalValueSummarySymtabCodes::FS_TYPE_TESTS => "TYPE_TESTS",
+                GlobalValueSummarySymtabCodes::FS_TYPE_TEST_ASSUME_VCALLS => {
+                    "TYPE_TEST_ASSUME_VCALLS"
+                }
+                GlobalValueSummarySymtabCodes::FS_TYPE_CHECKED_LOAD_VCALLS => {
+                    "TYPE_CHECKED_LOAD_VCALLS"
+                }
+                GlobalValueSummarySymtabCodes::FS_TYPE_TEST_ASSUME_CONST_VCALL => {
+                    "TYPE_TEST_ASSUME_CONST_VCALL"
+                }
+                GlobalValueSummarySymtabCodes::FS_TYPE_CHECKED_LOAD_CONST_VCALL => {
+                    "TYPE_CHECKED_LOAD_CONST_VCALL"
+                }
+                GlobalValueSummarySymtabCodes::FS_VALUE_GUID => "VALUE_GUID",
+                GlobalValueSummarySymtabCodes::FS_CFI_FUNCTION_DEFS => "CFI_FUNCTION_DEFS",
+                GlobalValueSummarySymtabCodes::FS_CFI_FUNCTION_DECLS => "CFI_FUNCTION_DECLS",
+                GlobalValueSummarySymtabCodes::FS_TYPE_ID => "TYPE_ID",
+                GlobalValueSummarySymtabCodes::FS_TYPE_ID_METADATA => "TYPE_ID_METADATA",
+                GlobalValueSummarySymtabCodes::FS_BLOCK_COUNT => "BLOCK_COUNT",
+                GlobalValueSummarySymtabCodes::FS_PARAM_ACCESS => "PARAM_ACCESS",
+                GlobalValueSummarySymtabCodes::FS_PERMODULE_CALLSITE_INFO => {
+                    "PERMODULE_CALLSITE_INFO"
+                }
+                GlobalValueSummarySymtabCodes::FS_PERMODULE_ALLOC_INFO => "PERMODULE_ALLOC_INFO",
+                GlobalValueSummarySymtabCodes::FS_COMBINED_CALLSITE_INFO => {
+                    "COMBINED_CALLSITE_INFO"
+                }
+                GlobalValueSummarySymtabCodes::FS_COMBINED_ALLOC_INFO => "COMBINED_ALLOC_INFO",
+                GlobalValueSummarySymtabCodes::FS_STACK_IDS => "STACK_IDS",
+                GlobalValueSummarySymtabCodes::FS_ALLOC_CONTEXT_IDS => "ALLOC_CONTEXT_IDS",
+                GlobalValueSummarySymtabCodes::FS_CONTEXT_RADIX_TREE_ARRAY => {
+                    "CONTEXT_RADIX_TREE_ARRAY"
+                }
+            }
+        }
+        crate::Blocks::METADATA_KIND_BLOCK_ID
+        | crate::Blocks::METADATA_BLOCK_ID
+        | Blocks::METADATA_ATTACHMENT_ID => match MetadataCodes::try_from(record).unwrap() {
+            MetadataCodes::METADATA_ATTACHMENT => "ATTACHMENT",
+            MetadataCodes::METADATA_STRING_OLD => "STRING_OLD",
+            MetadataCodes::METADATA_VALUE => "VALUE",
+            MetadataCodes::METADATA_NODE => "NODE",
+            MetadataCodes::METADATA_NAME => "NAME",
+            MetadataCodes::METADATA_DISTINCT_NODE => "DISTINCT_NODE",
+            MetadataCodes::METADATA_KIND => "KIND",
+            MetadataCodes::METADATA_LOCATION => "LOCATION",
+            MetadataCodes::METADATA_OLD_NODE => "OLD_NODE",
+            MetadataCodes::METADATA_OLD_FN_NODE => "OLD_FN_NODE",
+            MetadataCodes::METADATA_NAMED_NODE => "NAMED_NODE",
+            MetadataCodes::METADATA_GENERIC_DEBUG => "GENERIC_DEBUG",
+            MetadataCodes::METADATA_SUBRANGE => "SUBRANGE",
+            MetadataCodes::METADATA_ENUMERATOR => "ENUMERATOR",
+            MetadataCodes::METADATA_BASIC_TYPE => "BASIC_TYPE",
+            MetadataCodes::METADATA_FILE => "FILE",
+            MetadataCodes::METADATA_DERIVED_TYPE => "DERIVED_TYPE",
+            MetadataCodes::METADATA_COMPOSITE_TYPE => "COMPOSITE_TYPE",
+            MetadataCodes::METADATA_SUBROUTINE_TYPE => "SUBROUTINE_TYPE",
+            MetadataCodes::METADATA_COMPILE_UNIT => "COMPILE_UNIT",
+            MetadataCodes::METADATA_SUBPROGRAM => "SUBPROGRAM",
+            MetadataCodes::METADATA_LEXICAL_BLOCK => "LEXICAL_BLOCK",
+            MetadataCodes::METADATA_LEXICAL_BLOCK_FILE => "LEXICAL_BLOCK_FILE",
+            MetadataCodes::METADATA_NAMESPACE => "NAMESPACE",
+            MetadataCodes::METADATA_TEMPLATE_TYPE => "TEMPLATE_TYPE",
+            MetadataCodes::METADATA_TEMPLATE_VALUE => "TEMPLATE_VALUE",
+            MetadataCodes::METADATA_GLOBAL_VAR => "GLOBAL_VAR",
+            MetadataCodes::METADATA_LOCAL_VAR => "LOCAL_VAR",
+            MetadataCodes::METADATA_EXPRESSION => "EXPRESSION",
+            MetadataCodes::METADATA_OBJC_PROPERTY => "OBJC_PROPERTY",
+            MetadataCodes::METADATA_IMPORTED_ENTITY => "IMPORTED_ENTITY",
+            MetadataCodes::METADATA_MODULE => "MODULE",
+            MetadataCodes::METADATA_MACRO => "MACRO",
+            MetadataCodes::METADATA_MACRO_FILE => "MACRO_FILE",
+            MetadataCodes::METADATA_STRINGS => "STRINGS",
+            MetadataCodes::METADATA_GLOBAL_DECL_ATTACHMENT => "GLOBAL_DECL_ATTACHMENT",
+            MetadataCodes::METADATA_GLOBAL_VAR_EXPR => "GLOBAL_VAR_EXPR",
+            MetadataCodes::METADATA_INDEX_OFFSET => "INDEX_OFFSET",
+            MetadataCodes::METADATA_INDEX => "INDEX",
+            MetadataCodes::METADATA_ARG_LIST => "ARG_LIST",
+            MetadataCodes::METADATA_LABEL => "LABEL",
+            MetadataCodes::METADATA_STRING_TYPE => "STRING_TYPE",
+            MetadataCodes::METADATA_COMMON_BLOCK => "COMMON_BLOCK",
+            MetadataCodes::METADATA_GENERIC_SUBRANGE => "GENERIC_SUBRANGE",
+            MetadataCodes::METADATA_ASSIGN_ID => "ASSIGN_ID",
+        },
+        Blocks::USELIST_BLOCK_ID => match UseListCodes::try_from(record).unwrap() {
+            UseListCodes::USELIST_CODE_DEFAULT => "DEFAULT",
+            UseListCodes::USELIST_CODE_BB => "BB",
+        },
+        Blocks::OPERAND_BUNDLE_TAGS_BLOCK_ID => {
+            match OperandBundleTagCode::try_from(record).unwrap() {
+                OperandBundleTagCode::OPERAND_BUNDLE_TAG => "OPERAND_BUNDLE_TAG",
+            }
+        }
+        Blocks::STRTAB_BLOCK_ID => match StrtabCodes::try_from(record).unwrap() {
+            StrtabCodes::STRTAB_BLOB => "BLOB",
+        },
+        Blocks::SYMTAB_BLOCK_ID => match SymtabCodes::try_from(record).unwrap() {
+            SymtabCodes::SYMTAB_BLOB => "BLOB",
+        },
+        Blocks::SYNC_SCOPE_NAMES_BLOCK_ID => "UnknownCode1",
+    }
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum Blocks {
+    MODULE_BLOCK_ID = 8,
+    PARAMATTR_BLOCK_ID,
+    PARAMATTR_GROUP_BLOCK_ID,
+    CONSTANTS_BLOCK_ID,
+    FUNCTION_BLOCK_ID,
+    IDENTIFICATION_BLOCK_ID,
+    VALUE_SYMTAB_BLOCK_ID,
+    METADATA_BLOCK_ID,
+    METADATA_ATTACHMENT_ID,
+    TYPE_BLOCK_ID_NEW,
+    USELIST_BLOCK_ID,
+    MODULE_STRTAB_BLOCK_ID,
+    GLOBALVAL_SUMMARY_BLOCK_ID,
+    OPERAND_BUNDLE_TAGS_BLOCK_ID,
+    METADATA_KIND_BLOCK_ID,
+    STRTAB_BLOCK_ID,
+    FULL_LTO_GLOBALVAL_SUMMARY_BLOCK_ID,
+    SYMTAB_BLOCK_ID,
+    SYNC_SCOPE_NAMES_BLOCK_ID,
+}
+
+/// Identification block contains a string that describes the producer details,
+/// and an epoch that defines the auto-upgrade capability.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum IdentificationCodes {
+    IDENTIFICATION_CODE_STRING = 1, // IDENTIFICATION:      [strchr x N]
+    IDENTIFICATION_CODE_EPOCH = 2,  // EPOCH:               [epoch#]
+}
+
+/// The epoch that defines the auto-upgrade compatibility for the bitcode.
+///
+/// LLVM guarantees in a major release that a minor release can read bitcode
+/// generated by previous minor releases. We translate this by making the reader
+/// accepting only bitcode with the same epoch, except for the X.0 release which
+/// also accepts N-1.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum EpochCode {
+    BITCODE_CURRENT_EPOCH = 0,
+}
+
+/// MODULE blocks have a number of optional fields and subblocks.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum ModuleCodes {
+    MODULE_CODE_VERSION = 1,     // VERSION:     [version#]
+    MODULE_CODE_TRIPLE = 2,      // TRIPLE:      [strchr x N]
+    MODULE_CODE_DATALAYOUT = 3,  // DATALAYOUT:  [strchr x N]
+    MODULE_CODE_ASM = 4,         // ASM:         [strchr x N]
+    MODULE_CODE_SECTIONNAME = 5, // SECTIONNAME: [strchr x N]
+
+    // Deprecated, but still needed to read old bitcode files.
+    MODULE_CODE_DEPLIB = 6, // DEPLIB:      [strchr x N]
+
+    // GLOBALVAR: [pointer type, isconst, initid,
+    //             linkage, alignment, section, visibility, threadlocal]
+    MODULE_CODE_GLOBALVAR = 7,
+
+    // FUNCTION:  [type, callingconv, isproto, linkage, paramattrs, alignment,
+    //             section, visibility, gc, unnamed_addr]
+    MODULE_CODE_FUNCTION = 8,
+
+    // ALIAS: [alias type, aliasee val#, linkage, visibility]
+    MODULE_CODE_ALIAS_OLD = 9,
+
+    MODULE_CODE_GCNAME = 11, // GCNAME: [strchr x N]
+    MODULE_CODE_COMDAT = 12, // COMDAT: [selection_kind, name]
+
+    MODULE_CODE_VSTOFFSET = 13, // VSTOFFSET: [offset]
+
+    // ALIAS: [alias value type, addrspace, aliasee val#, linkage, visibility]
+    MODULE_CODE_ALIAS = 14,
+
+    MODULE_CODE_METADATA_VALUES_UNUSED = 15,
+
+    // SOURCE_FILENAME: [namechar x N]
+    MODULE_CODE_SOURCE_FILENAME = 16,
+
+    // HASH: [5*i32]
+    MODULE_CODE_HASH = 17,
+
+    // IFUNC: [ifunc value type, addrspace, resolver val#, linkage, visibility]
+    MODULE_CODE_IFUNC = 18,
+}
+
+/// PARAMATTR blocks have code for defining a parameter attribute set.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum AttributeCodes {
+    // Deprecated, but still needed to read old bitcode files.
+    PARAMATTR_CODE_ENTRY_OLD = 1, // ENTRY: [paramidx0, attr0,
+    //         paramidx1, attr1...]
+    PARAMATTR_CODE_ENTRY = 2,     // ENTRY: [attrgrp0, attrgrp1, ...]
+    PARAMATTR_GRP_CODE_ENTRY = 3, // ENTRY: [grpid, idx, attr0, attr1, ...]
+}
+
+/// TYPE blocks have codes for each type primitive they use.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum TypeCodes {
+    TYPE_CODE_NUMENTRY = 1, // NUMENTRY: [numentries]
+
+    // Type Codes
+    TYPE_CODE_VOID = 2,    // VOID
+    TYPE_CODE_FLOAT = 3,   // FLOAT
+    TYPE_CODE_DOUBLE = 4,  // DOUBLE
+    TYPE_CODE_LABEL = 5,   // LABEL
+    TYPE_CODE_OPAQUE = 6,  // OPAQUE
+    TYPE_CODE_INTEGER = 7, // INTEGER: [width]
+    TYPE_CODE_POINTER = 8, // POINTER: [pointee type]
+
+    TYPE_CODE_FUNCTION_OLD = 9, // FUNCTION: [vararg, attrid, retty,
+    //            paramty x N]
+    TYPE_CODE_HALF = 10, // HALF
+
+    TYPE_CODE_ARRAY = 11,  // ARRAY: [num_elements, elements_type]
+    TYPE_CODE_VECTOR = 12, // VECTOR: [num_elements, elements_type]
+
+    // These are not with the other floating point types because they're
+    // a late addition, and putting them in the right place breaks
+    // binary compatibility.
+    TYPE_CODE_X86_FP80 = 13,  // X86 LONG DOUBLE
+    TYPE_CODE_FP128 = 14,     // LONG DOUBLE (112 bit mantissa)
+    TYPE_CODE_PPC_FP128 = 15, // PPC LONG DOUBLE (2 doubles)
+
+    TYPE_CODE_METADATA = 16, // METADATA
+
+    TYPE_CODE_X86_MMX = 17, // X86 MMX
+
+    TYPE_CODE_STRUCT_ANON = 18, // STRUCT_ANON: [ispacked, elements_type x N]
+    TYPE_CODE_STRUCT_NAME = 19, // STRUCT_NAME: [strchr x N]
+    TYPE_CODE_STRUCT_NAMED = 20, // STRUCT_NAMED: [ispacked, elements_type x N]
+
+    TYPE_CODE_FUNCTION = 21, // FUNCTION: [vararg, retty, paramty x N]
+
+    TYPE_CODE_TOKEN = 22, // TOKEN
+
+    TYPE_CODE_BFLOAT = 23,  // BRAIN FLOATING POINT
+    TYPE_CODE_X86_AMX = 24, // X86 AMX
+
+    TYPE_CODE_OPAQUE_POINTER = 25, // OPAQUE_POINTER: [addrspace]
+
+    TYPE_CODE_TARGET_TYPE = 26, // TARGET_TYPE
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum OperandBundleTagCode {
+    OPERAND_BUNDLE_TAG = 1, // TAG: [strchr x N]
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum SyncScopeNameCode {
+    SYNC_SCOPE_NAME = 1,
+}
+
+// Value symbol table codes.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum ValueSymtabCodes {
+    VST_CODE_ENTRY = 1,   // VST_ENTRY: [valueid, namechar x N]
+    VST_CODE_BBENTRY = 2, // VST_BBENTRY: [bbid, namechar x N]
+    VST_CODE_FNENTRY = 3, // VST_FNENTRY: [valueid, offset, namechar x N]
+    // VST_COMBINED_ENTRY: [valueid, refguid]
+    VST_CODE_COMBINED_ENTRY = 5,
+}
+
+// The module path symbol table only has one code (MST_CODE_ENTRY).
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum ModulePathSymtabCodes {
+    MST_CODE_ENTRY = 1, // MST_ENTRY: [modid, namechar x N]
+    MST_CODE_HASH = 2,  // MST_HASH:  [5*i32]
+}
+
+// The summary section uses different codes in the per-module
+// and combined index cases.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum GlobalValueSummarySymtabCodes {
+    // PERMODULE: [valueid, flags, instcount, numrefs, numrefs x valueid,
+    //             n x (valueid)]
+    FS_PERMODULE = 1,
+    // PERMODULE_PROFILE: [valueid, flags, instcount, numrefs,
+    //                     numrefs x valueid,
+    //                     n x (valueid, hotness+tailcall)]
+    FS_PERMODULE_PROFILE = 2,
+    // PERMODULE_GLOBALVAR_INIT_REFS: [valueid, flags, n x valueid]
+    FS_PERMODULE_GLOBALVAR_INIT_REFS = 3,
+    // COMBINED: [valueid, modid, flags, instcount, numrefs, numrefs x valueid,
+    //            n x (valueid)]
+    FS_COMBINED = 4,
+    // COMBINED_PROFILE: [valueid, modid, flags, instcount, numrefs,
+    //                    numrefs x valueid,
+    //                    n x (valueid, hotness+tailcall)]
+    FS_COMBINED_PROFILE = 5,
+    // COMBINED_GLOBALVAR_INIT_REFS: [valueid, modid, flags, n x valueid]
+    FS_COMBINED_GLOBALVAR_INIT_REFS = 6,
+    // ALIAS: [valueid, flags, valueid]
+    FS_ALIAS = 7,
+    // COMBINED_ALIAS: [valueid, modid, flags, valueid]
+    FS_COMBINED_ALIAS = 8,
+    // COMBINED_ORIGINAL_NAME: [original_name_hash]
+    FS_COMBINED_ORIGINAL_NAME = 9,
+    // VERSION of the summary, bumped when adding flags for instance.
+    FS_VERSION = 10,
+    // The list of llvm.type.test type identifiers used by the following function
+    // that are used other than by an llvm.assume.
+    // [n x typeid]
+    FS_TYPE_TESTS = 11,
+    // The list of virtual calls made by this function using
+    // llvm.assume(llvm.type.test) intrinsics that do not have all constant
+    // integer arguments.
+    // [n x (typeid, offset)]
+    FS_TYPE_TEST_ASSUME_VCALLS = 12,
+    // The list of virtual calls made by this function using
+    // llvm.type.checked.load intrinsics that do not have all constant integer
+    // arguments.
+    // [n x (typeid, offset)]
+    FS_TYPE_CHECKED_LOAD_VCALLS = 13,
+    // Identifies a virtual call made by this function using an
+    // llvm.assume(llvm.type.test) intrinsic with all constant integer arguments.
+    // [typeid, offset, n x arg]
+    FS_TYPE_TEST_ASSUME_CONST_VCALL = 14,
+    // Identifies a virtual call made by this function using an
+    // llvm.type.checked.load intrinsic with all constant integer arguments.
+    // [typeid, offset, n x arg]
+    FS_TYPE_CHECKED_LOAD_CONST_VCALL = 15,
+    // Assigns a GUID to a value ID. This normally appears only in combined
+    // summaries, but it can also appear in per-module summaries for PGO data.
+    // [valueid, guid]
+    FS_VALUE_GUID = 16,
+    // The list of local functions with CFI jump tables. Function names are
+    // strings in strtab.
+    // [n * name]
+    FS_CFI_FUNCTION_DEFS = 17,
+    // The list of external functions with CFI jump tables. Function names are
+    // strings in strtab.
+    // [n * name]
+    FS_CFI_FUNCTION_DECLS = 18,
+    // Per-module summary that also adds relative block frequency to callee info.
+    // PERMODULE_RELBF: [valueid, flags, instcount, numrefs,
+    //                   numrefs x valueid,
+    //                   n x (valueid, relblockfreq+tailcall)]
+    FS_PERMODULE_RELBF = 19,
+    // Index-wide flags
+    FS_FLAGS = 20,
+    // Maps type identifier to summary information for that type identifier.
+    // Produced by the thin link (only lives in combined index).
+    // TYPE_ID: [typeid, kind, bitwidth, align, size, bitmask, inlinebits,
+    //           n x (typeid, kind, name, numrba,
+    //                numrba x (numarg, numarg x arg, kind, info, byte, bit))]
+    FS_TYPE_ID = 21,
+    // For background see overview at https://llvm.org/docs/TypeMetadata.html.
+    // The type metadata includes both the type identifier and the offset of
+    // the address point of the type (the address held by objects of that type
+    // which may not be the beginning of the virtual table). Vtable definitions
+    // are decorated with type metadata for the types they are compatible with.
+    //
+    // Maps type identifier to summary information for that type identifier
+    // computed from type metadata: the valueid of each vtable definition
+    // decorated with a type metadata for that identifier, and the offset from
+    // the corresponding type metadata.
+    // Exists in the per-module summary to provide information to thin link
+    // for index-based whole program devirtualization.
+    // TYPE_ID_METADATA: [typeid, n x (valueid, offset)]
+    FS_TYPE_ID_METADATA = 22,
+    // Summarizes vtable definition for use in index-based whole program
+    // devirtualization during the thin link.
+    // PERMODULE_VTABLE_GLOBALVAR_INIT_REFS: [valueid, flags, varflags,
+    //                                        numrefs, numrefs x valueid,
+    //                                        n x (valueid, offset)]
+    FS_PERMODULE_VTABLE_GLOBALVAR_INIT_REFS = 23,
+    // The total number of basic blocks in the module.
+    FS_BLOCK_COUNT = 24,
+    // Range information for accessed offsets for every argument.
+    // [n x (paramno, range, numcalls, numcalls x (callee_guid, paramno, range))]
+    FS_PARAM_ACCESS = 25,
+    // Summary of per-module memprof callsite metadata.
+    // [valueid, n x stackidindex]
+    FS_PERMODULE_CALLSITE_INFO = 26,
+    // Summary of per-module allocation memprof metadata.
+    // [nummib, nummib x (alloc type, context radix tree index),
+    // [nummib x (numcontext x total size)]?]
+    FS_PERMODULE_ALLOC_INFO = 27,
+    // Summary of combined index memprof callsite metadata.
+    // [valueid, context radix tree index, numver,
+    //  numver x version]
+    FS_COMBINED_CALLSITE_INFO = 28,
+    // Summary of combined index allocation memprof metadata.
+    // [nummib, numver,
+    //  nummib x (alloc type, numstackids, numstackids x stackidindex),
+    //  numver x version]
+    FS_COMBINED_ALLOC_INFO = 29,
+    // List of all stack ids referenced by index in the callsite and alloc infos.
+    // [n x stack id]
+    FS_STACK_IDS = 30,
+    // List of all full stack id pairs corresponding to the total sizes recorded
+    // at the end of the alloc info when reporting of hinted bytes is enabled.
+    // We use a fixed-width array, which is more efficient as these ids typically
+    // are close to 64 bits in size. The max fixed width value supported is 32
+    // bits so each 64-bit context id hash is recorded as a pair (upper 32 bits
+    // first). This record must immediately precede the associated alloc info, and
+    // the entries must be in the exact same order as the corresponding sizes.
+    // [nummib x (numcontext x full stack id)]
+    FS_ALLOC_CONTEXT_IDS = 31,
+    // Linearized radix tree of allocation contexts. See the description above the
+    // CallStackRadixTreeBuilder class in ProfileData/MemProf.h for format.
+    // [n x entry]
+    FS_CONTEXT_RADIX_TREE_ARRAY = 32,
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum MetadataCodes {
+    METADATA_STRING_OLD = 1,              // MDSTRING:      [values]
+    METADATA_VALUE = 2,                   // VALUE:         [type num, value num]
+    METADATA_NODE = 3,                    // NODE:          [n x md num]
+    METADATA_NAME = 4,                    // STRING:        [values]
+    METADATA_DISTINCT_NODE = 5,           // DISTINCT_NODE: [n x md num]
+    METADATA_KIND = 6,                    // [n x [id, name]]
+    METADATA_LOCATION = 7,                // [distinct, line, col, scope, inlined-at?]
+    METADATA_OLD_NODE = 8,                // OLD_NODE:      [n x (type num, value num)]
+    METADATA_OLD_FN_NODE = 9,             // OLD_FN_NODE:   [n x (type num, value num)]
+    METADATA_NAMED_NODE = 10,             // NAMED_NODE:    [n x mdnodes]
+    METADATA_ATTACHMENT = 11,             // [m x [value, [n x [id, mdnode]]]
+    METADATA_GENERIC_DEBUG = 12,          // [distinct, tag, vers, header, n x md num]
+    METADATA_SUBRANGE = 13,               // [distinct, count, lo]
+    METADATA_ENUMERATOR = 14,             // [isUnsigned|distinct, value, name]
+    METADATA_BASIC_TYPE = 15,             // [distinct, tag, name, size, align, enc]
+    METADATA_FILE = 16,                   // [distinct, filename, directory, checksumkind, checksum]
+    METADATA_DERIVED_TYPE = 17,           // [distinct, ...]
+    METADATA_COMPOSITE_TYPE = 18,         // [distinct, ...]
+    METADATA_SUBROUTINE_TYPE = 19,        // [distinct, flags, types, cc]
+    METADATA_COMPILE_UNIT = 20,           // [distinct, ...]
+    METADATA_SUBPROGRAM = 21,             // [distinct, ...]
+    METADATA_LEXICAL_BLOCK = 22,          // [distinct, scope, file, line, column]
+    METADATA_LEXICAL_BLOCK_FILE = 23,     //[distinct, scope, file, discriminator]
+    METADATA_NAMESPACE = 24,              // [distinct, scope, file, name, line, exportSymbols]
+    METADATA_TEMPLATE_TYPE = 25,          // [distinct, scope, name, type, ...]
+    METADATA_TEMPLATE_VALUE = 26,         // [distinct, scope, name, type, value, ...]
+    METADATA_GLOBAL_VAR = 27,             // [distinct, ...]
+    METADATA_LOCAL_VAR = 28,              // [distinct, ...]
+    METADATA_EXPRESSION = 29,             // [distinct, n x element]
+    METADATA_OBJC_PROPERTY = 30,          // [distinct, name, file, line, ...]
+    METADATA_IMPORTED_ENTITY = 31,        // [distinct, tag, scope, entity, line, name]
+    METADATA_MODULE = 32,                 // [distinct, scope, name, ...]
+    METADATA_MACRO = 33,                  // [distinct, macinfo, line, name, value]
+    METADATA_MACRO_FILE = 34,             // [distinct, macinfo, line, file, ...]
+    METADATA_STRINGS = 35,                // [count, offset] blob([lengths][chars])
+    METADATA_GLOBAL_DECL_ATTACHMENT = 36, // [valueid, n x [id, mdnode]]
+    METADATA_GLOBAL_VAR_EXPR = 37,        // [distinct, var, expr]
+    METADATA_INDEX_OFFSET = 38,           // [offset]
+    METADATA_INDEX = 39,                  // [bitpos]
+    METADATA_LABEL = 40,                  // [distinct, scope, name, file, line]
+    METADATA_STRING_TYPE = 41,            // [distinct, name, size, align,...]
+    // Codes 42 and 43 are reserved for support for Fortran array specific debug
+    // info.
+    METADATA_COMMON_BLOCK = 44, // [distinct, scope, name, variable,...]
+    METADATA_GENERIC_SUBRANGE = 45, // [distinct, count, lo, up, stride]
+    METADATA_ARG_LIST = 46,     // [n x [type num, value num]]
+    METADATA_ASSIGN_ID = 47,    // [distinct, ...]
+}
+
+// The constants block (CONSTANTS_BLOCK_ID) describes emission for each
+// constant and maintains an implicit current type value.
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum ConstantsCodes {
+    CST_CODE_SETTYPE = 1,        // SETTYPE:       [typeid]
+    CST_CODE_NULL = 2,           // NULL
+    CST_CODE_UNDEF = 3,          // UNDEF
+    CST_CODE_INTEGER = 4,        // INTEGER:       [intval]
+    CST_CODE_WIDE_INTEGER = 5,   // WIDE_INTEGER:  [n x intval]
+    CST_CODE_FLOAT = 6,          // FLOAT:         [fpval]
+    CST_CODE_AGGREGATE = 7,      // AGGREGATE:     [n x value number]
+    CST_CODE_STRING = 8,         // STRING:        [values]
+    CST_CODE_CSTRING = 9,        // CSTRING:       [values]
+    CST_CODE_CE_BINOP = 10,      // CE_BINOP:      [opcode, opval, opval]
+    CST_CODE_CE_CAST = 11,       // CE_CAST:       [opcode, opty, opval]
+    CST_CODE_CE_GEP_OLD = 12,    // CE_GEP:        [n x operands]
+    CST_CODE_CE_SELECT = 13,     // CE_SELECT:     [opval, opval, opval]
+    CST_CODE_CE_EXTRACTELT = 14, // CE_EXTRACTELT: [opty, opval, opval]
+    CST_CODE_CE_INSERTELT = 15,  // CE_INSERTELT:  [opval, opval, opval]
+    CST_CODE_CE_SHUFFLEVEC = 16, // CE_SHUFFLEVEC: [opval, opval, opval]
+    CST_CODE_CE_CMP = 17,        // CE_CMP:        [opty, opval, opval, pred]
+    CST_CODE_INLINEASM_OLD = 18, // INLINEASM:     [sideeffect|alignstack,
+    //                 asmstr,conststr]
+    CST_CODE_CE_SHUFVEC_EX = 19, // SHUFVEC_EX:    [opty, opval, opval, opval]
+    CST_CODE_CE_INBOUNDS_GEP = 20, // INBOUNDS_GEP:  [n x operands]
+    CST_CODE_BLOCKADDRESS = 21,  // CST_CODE_BLOCKADDRESS [fnty, fnval, bb#]
+    CST_CODE_DATA = 22,          // DATA:          [n x elements]
+    CST_CODE_INLINEASM_OLD2 = 23, // INLINEASM:     [sideeffect|alignstack|
+    //                 asmdialect,asmstr,conststr]
+    CST_CODE_CE_GEP_WITH_INRANGE_INDEX_OLD = 24, //  [opty, flags, n x operands]
+    CST_CODE_CE_UNOP = 25,                       // CE_UNOP:      [opcode, opval]
+    CST_CODE_POISON = 26,                        // POISON
+    CST_CODE_DSO_LOCAL_EQUIVALENT = 27,          // DSO_LOCAL_EQUIVALENT [gvty, gv]
+    CST_CODE_INLINEASM_OLD3 = 28,                // INLINEASM:     [sideeffect|alignstack|
+    //                 asmdialect|unwind,
+    //                 asmstr,conststr]
+    CST_CODE_NO_CFI_VALUE = 29, // NO_CFI [ fty, f ]
+    CST_CODE_INLINEASM = 30,    // INLINEASM:     [fnty,
+    //                 sideeffect|alignstack|
+    //                 asmdialect|unwind,
+    //                 asmstr,conststr]
+    CST_CODE_CE_GEP_WITH_INRANGE = 31, // [opty, flags, range, n x operands]
+    CST_CODE_CE_GEP = 32,              // [opty, flags, n x operands]
+    CST_CODE_PTRAUTH = 33,             // [ptr, key, disc, addrdisc]
+}
+
+// The function body block (FUNCTION_BLOCK_ID) describes function bodies.  It
+// can contain a constant block (CONSTANTS_BLOCK_ID).
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum FunctionCodes {
+    FUNC_CODE_DECLAREBLOCKS = 1, // DECLAREBLOCKS: [n]
+
+    FUNC_CODE_INST_BINOP = 2,      // BINOP:      [opcode, ty, opval, opval]
+    FUNC_CODE_INST_CAST = 3,       // CAST:       [opcode, ty, opty, opval]
+    FUNC_CODE_INST_GEP_OLD = 4,    // GEP:        [n x operands]
+    FUNC_CODE_INST_SELECT = 5,     // SELECT:     [ty, opval, opval, opval]
+    FUNC_CODE_INST_EXTRACTELT = 6, // EXTRACTELT: [opty, opval, opval]
+    FUNC_CODE_INST_INSERTELT = 7,  // INSERTELT:  [ty, opval, opval, opval]
+    FUNC_CODE_INST_SHUFFLEVEC = 8, // SHUFFLEVEC: [ty, opval, opval, opval]
+    FUNC_CODE_INST_CMP = 9,        // CMP:        [opty, opval, opval, pred]
+
+    FUNC_CODE_INST_RET = 10,    // RET:        [opty,opval<both optional>]
+    FUNC_CODE_INST_BR = 11,     // BR:         [bb#, bb#, cond] or [bb#]
+    FUNC_CODE_INST_SWITCH = 12, // SWITCH:     [opty, op0, op1, ...]
+    FUNC_CODE_INST_INVOKE = 13, // INVOKE:     [attr, fnty, op0,op1, ...]
+    // 14 is unused.
+    FUNC_CODE_INST_UNREACHABLE = 15, // UNREACHABLE
+
+    FUNC_CODE_INST_PHI = 16, // PHI:        [ty, val0,bb0, ...]
+    // 17 is unused.
+    // 18 is unused.
+    FUNC_CODE_INST_ALLOCA = 19, // ALLOCA:     [instty, opty, op, align]
+    FUNC_CODE_INST_LOAD = 20,   // LOAD:       [opty, op, align, vol]
+    // 21 is unused.
+    // 22 is unused.
+    FUNC_CODE_INST_VAARG = 23, // VAARG:      [valistty, valist, instty]
+    // This store code encodes the pointer type, rather than the value type
+    // this is so information only available in the pointer type (e.g. address
+    // spaces) is retained.
+    FUNC_CODE_INST_STORE_OLD = 24, // STORE:      [ptrty,ptr,val, align, vol]
+    // 25 is unused.
+    FUNC_CODE_INST_EXTRACTVAL = 26, // EXTRACTVAL: [n x operands]
+    FUNC_CODE_INST_INSERTVAL = 27,  // INSERTVAL:  [n x operands]
+    // fcmp/icmp returning Int1TY or vector of Int1Ty. Same as CMP, exists to
+    // support legacy vicmp/vfcmp instructions.
+    FUNC_CODE_INST_CMP2 = 28, // CMP2:       [opty, opval, opval, pred]
+    // new select on i1 or [N x i1]
+    FUNC_CODE_INST_VSELECT = 29, // VSELECT:    [ty,opval,opval,predty,pred]
+    FUNC_CODE_INST_INBOUNDS_GEP_OLD = 30, // INBOUNDS_GEP: [n x operands]
+    FUNC_CODE_INST_INDIRECTBR = 31, // INDIRECTBR: [opty, op0, op1, ...]
+    // 32 is unused.
+    FUNC_CODE_DEBUG_LOC_AGAIN = 33, // DEBUG_LOC_AGAIN
+
+    FUNC_CODE_INST_CALL = 34, // CALL:    [attr, cc, fnty, fnid, args...]
+
+    FUNC_CODE_DEBUG_LOC = 35,  // DEBUG_LOC:  [Line,Col,ScopeVal, IAVal]
+    FUNC_CODE_INST_FENCE = 36, // FENCE: [ordering, synchscope]
+    FUNC_CODE_INST_CMPXCHG_OLD = 37, // CMPXCHG: [ptrty, ptr, cmp, val, vol,
+    //            ordering, synchscope,
+    //            failure_ordering?, weak?]
+    FUNC_CODE_INST_ATOMICRMW_OLD = 38, // ATOMICRMW: [ptrty,ptr,val, operation,
+    //             align, vol,
+    //             ordering, synchscope]
+    FUNC_CODE_INST_RESUME = 39,         // RESUME:     [opval]
+    FUNC_CODE_INST_LANDINGPAD_OLD = 40, // LANDINGPAD: [ty,val,val,num,id0,val0...]
+    FUNC_CODE_INST_LOADATOMIC = 41,     // LOAD: [opty, op, align, vol,
+    //        ordering, synchscope]
+    FUNC_CODE_INST_STOREATOMIC_OLD = 42, // STORE: [ptrty,ptr,val, align, vol
+    //         ordering, synchscope]
+    FUNC_CODE_INST_GEP = 43,         // GEP:  [inbounds, n x operands]
+    FUNC_CODE_INST_STORE = 44,       // STORE: [ptrty,ptr,valty,val, align, vol]
+    FUNC_CODE_INST_STOREATOMIC = 45, // STORE: [ptrty,ptr,val, align, vol
+    FUNC_CODE_INST_CMPXCHG = 46,     // CMPXCHG: [ptrty, ptr, cmp, val, vol,
+    //           success_ordering, synchscope,
+    //           failure_ordering, weak]
+    FUNC_CODE_INST_LANDINGPAD = 47, // LANDINGPAD: [ty,val,num,id0,val0...]
+    FUNC_CODE_INST_CLEANUPRET = 48, // CLEANUPRET: [val] or [val,bb#]
+    FUNC_CODE_INST_CATCHRET = 49,   // CATCHRET: [val,bb#]
+    FUNC_CODE_INST_CATCHPAD = 50,   // CATCHPAD: [bb#,bb#,num,args...]
+    FUNC_CODE_INST_CLEANUPPAD = 51, // CLEANUPPAD: [num,args...]
+    FUNC_CODE_INST_CATCHSWITCH = 52, // CATCHSWITCH: [num,args...] or [num,args...,bb]
+    // 53 is unused.
+    // 54 is unused.
+    FUNC_CODE_OPERAND_BUNDLE = 55, // OPERAND_BUNDLE: [tag#, value...]
+    FUNC_CODE_INST_UNOP = 56,      // UNOP:       [opcode, ty, opval]
+    FUNC_CODE_INST_CALLBR = 57,    // CALLBR:     [attr, cc, norm, transfs,
+    //              fnty, fnid, args...]
+    FUNC_CODE_INST_FREEZE = 58,    // FREEZE: [opty, opval]
+    FUNC_CODE_INST_ATOMICRMW = 59, // ATOMICRMW: [ptrty, ptr, valty, val,
+    //             operation, align, vol,
+    //             ordering, synchscope]
+    FUNC_CODE_BLOCKADDR_USERS = 60, // BLOCKADDR_USERS: [value...]
+
+    FUNC_CODE_DEBUG_RECORD_VALUE = 61, // [DILocation, DILocalVariable, DIExpression, ValueAsMetadata]
+    FUNC_CODE_DEBUG_RECORD_DECLARE = 62, // [DILocation, DILocalVariable, DIExpression, ValueAsMetadata]
+    FUNC_CODE_DEBUG_RECORD_ASSIGN = 63, // [DILocation, DILocalVariable, DIExpression, ValueAsMetadata,
+    //  DIAssignID, DIExpression (addr), ValueAsMetadata (addr)]
+    FUNC_CODE_DEBUG_RECORD_VALUE_SIMPLE = 64, // [DILocation, DILocalVariable, DIExpression, Value]
+    FUNC_CODE_DEBUG_RECORD_LABEL = 65,        // [DILocation, DILabel]
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum UseListCodes {
+    USELIST_CODE_DEFAULT = 1, // DEFAULT: [index..., value-id]
+    USELIST_CODE_BB = 2,      // BB: [index..., bb-id]
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum AttributeKindCodes {
+    // = 0 is unused
+    ATTR_KIND_ALIGNMENT = 1,
+    ATTR_KIND_ALWAYS_INLINE = 2,
+    ATTR_KIND_BY_VAL = 3,
+    ATTR_KIND_INLINE_HINT = 4,
+    ATTR_KIND_IN_REG = 5,
+    ATTR_KIND_MIN_SIZE = 6,
+    ATTR_KIND_NAKED = 7,
+    ATTR_KIND_NEST = 8,
+    ATTR_KIND_NO_ALIAS = 9,
+    ATTR_KIND_NO_BUILTIN = 10,
+    ATTR_KIND_NO_CAPTURE = 11,
+    ATTR_KIND_NO_DUPLICATE = 12,
+    ATTR_KIND_NO_IMPLICIT_FLOAT = 13,
+    ATTR_KIND_NO_INLINE = 14,
+    ATTR_KIND_NON_LAZY_BIND = 15,
+    ATTR_KIND_NO_RED_ZONE = 16,
+    ATTR_KIND_NO_RETURN = 17,
+    ATTR_KIND_NO_UNWIND = 18,
+    ATTR_KIND_OPTIMIZE_FOR_SIZE = 19,
+    ATTR_KIND_READ_NONE = 20,
+    ATTR_KIND_READ_ONLY = 21,
+    ATTR_KIND_RETURNED = 22,
+    ATTR_KIND_RETURNS_TWICE = 23,
+    ATTR_KIND_S_EXT = 24,
+    ATTR_KIND_STACK_ALIGNMENT = 25,
+    ATTR_KIND_STACK_PROTECT = 26,
+    ATTR_KIND_STACK_PROTECT_REQ = 27,
+    ATTR_KIND_STACK_PROTECT_STRONG = 28,
+    ATTR_KIND_STRUCT_RET = 29,
+    ATTR_KIND_SANITIZE_ADDRESS = 30,
+    ATTR_KIND_SANITIZE_THREAD = 31,
+    ATTR_KIND_SANITIZE_MEMORY = 32,
+    ATTR_KIND_UW_TABLE = 33,
+    ATTR_KIND_Z_EXT = 34,
+    ATTR_KIND_BUILTIN = 35,
+    ATTR_KIND_COLD = 36,
+    ATTR_KIND_OPTIMIZE_NONE = 37,
+    ATTR_KIND_IN_ALLOCA = 38,
+    ATTR_KIND_NON_NULL = 39,
+    ATTR_KIND_JUMP_TABLE = 40,
+    ATTR_KIND_DEREFERENCEABLE = 41,
+    ATTR_KIND_DEREFERENCEABLE_OR_NULL = 42,
+    ATTR_KIND_CONVERGENT = 43,
+    ATTR_KIND_SAFESTACK = 44,
+    ATTR_KIND_ARGMEMONLY = 45,
+    ATTR_KIND_SWIFT_SELF = 46,
+    ATTR_KIND_SWIFT_ERROR = 47,
+    ATTR_KIND_NO_RECURSE = 48,
+    ATTR_KIND_INACCESSIBLEMEM_ONLY = 49,
+    ATTR_KIND_INACCESSIBLEMEM_OR_ARGMEMONLY = 50,
+    ATTR_KIND_ALLOC_SIZE = 51,
+    ATTR_KIND_WRITEONLY = 52,
+    ATTR_KIND_SPECULATABLE = 53,
+    ATTR_KIND_STRICT_FP = 54,
+    ATTR_KIND_SANITIZE_HWADDRESS = 55,
+    ATTR_KIND_NOCF_CHECK = 56,
+    ATTR_KIND_OPT_FOR_FUZZING = 57,
+    ATTR_KIND_SHADOWCALLSTACK = 58,
+    ATTR_KIND_SPECULATIVE_LOAD_HARDENING = 59,
+    ATTR_KIND_IMMARG = 60,
+    ATTR_KIND_WILLRETURN = 61,
+    ATTR_KIND_NOFREE = 62,
+    ATTR_KIND_NOSYNC = 63,
+    ATTR_KIND_SANITIZE_MEMTAG = 64,
+    ATTR_KIND_PREALLOCATED = 65,
+    ATTR_KIND_NO_MERGE = 66,
+    ATTR_KIND_NULL_POINTER_IS_VALID = 67,
+    ATTR_KIND_NOUNDEF = 68,
+    ATTR_KIND_BYREF = 69,
+    ATTR_KIND_MUSTPROGRESS = 70,
+    ATTR_KIND_NO_CALLBACK = 71,
+    ATTR_KIND_HOT = 72,
+    ATTR_KIND_NO_PROFILE = 73,
+    ATTR_KIND_VSCALE_RANGE = 74,
+    ATTR_KIND_SWIFT_ASYNC = 75,
+    ATTR_KIND_NO_SANITIZE_COVERAGE = 76,
+    ATTR_KIND_ELEMENTTYPE = 77,
+    ATTR_KIND_DISABLE_SANITIZER_INSTRUMENTATION = 78,
+    ATTR_KIND_NO_SANITIZE_BOUNDS = 79,
+    ATTR_KIND_ALLOC_ALIGN = 80,
+    ATTR_KIND_ALLOCATED_POINTER = 81,
+    ATTR_KIND_ALLOC_KIND = 82,
+    ATTR_KIND_PRESPLIT_COROUTINE = 83,
+    ATTR_KIND_FNRETTHUNK_EXTERN = 84,
+    ATTR_KIND_SKIP_PROFILE = 85,
+    ATTR_KIND_MEMORY = 86,
+    ATTR_KIND_NOFPCLASS = 87,
+    ATTR_KIND_OPTIMIZE_FOR_DEBUGGING = 88,
+    ATTR_KIND_WRITABLE = 89,
+    ATTR_KIND_CORO_ONLY_DESTROY_WHEN_COMPLETE = 90,
+    ATTR_KIND_DEAD_ON_UNWIND = 91,
+    ATTR_KIND_RANGE = 92,
+    ATTR_KIND_SANITIZE_NUMERICAL_STABILITY = 93,
+    ATTR_KIND_INITIALIZES = 94,
+    ATTR_KIND_HYBRID_PATCHABLE = 95,
+    ATTR_KIND_SANITIZE_REALTIME = 96,
+    ATTR_KIND_SANITIZE_REALTIME_BLOCKING = 97,
+    ATTR_KIND_CORO_ELIDE_SAFE = 98,
+    ATTR_KIND_NO_EXT = 99,
+    ATTR_KIND_NO_DIVERGENCE_SOURCE = 100,
+    ATTR_KIND_SANITIZE_TYPE = 101,
+    ATTR_KIND_CAPTURES = 102,
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum ComdatSelectionKindCodes {
+    COMDAT_SELECTION_KIND_ANY = 1,
+    COMDAT_SELECTION_KIND_EXACT_MATCH = 2,
+    COMDAT_SELECTION_KIND_LARGEST = 3,
+    COMDAT_SELECTION_KIND_NO_DUPLICATES = 4,
+    COMDAT_SELECTION_KIND_SAME_SIZE = 5,
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum StrtabCodes {
+    STRTAB_BLOB = 1,
+}
+
+#[derive(TryFromPrimitive)]
+#[repr(u32)]
+enum SymtabCodes {
+    SYMTAB_BLOB = 1,
+}

--- a/examples/parse_records.rs
+++ b/examples/parse_records.rs
@@ -1,0 +1,1913 @@
+#[derive(Debug)]
+pub struct BBInstruction {
+    pub index: InstIndex, // instruction Id
+    pub value_id: Option<ValueId>,
+    pub inst: Inst,
+}
+
+#[derive(Debug)]
+pub struct BasicBlock {
+    pub name: Option<String>,
+    pub inst: Vec<BBInstruction>,
+}
+
+#[derive(Debug)]
+pub struct Function {
+    record: ModuleFunctionRecord,
+    /// `ValIDs` lower than this are looked up in the global value list,
+    /// and higher ones are in the local value list.
+    first_local_value_list_id: ValueId,
+    local_value_list: Vec<Value>,
+    basic_blocks: Vec<BasicBlock>,
+
+    /// This is incremented for all instructions, even `Void` ones.
+    /// Debug metadata does not increment this.
+    instruction_counter: InstIndex,
+    /// function-local ones
+    metadata: Vec<MetadataRecord>,
+    inst_metadata_attachment: HashMap<InstIndex, Vec<(MetadataKindId, MetadataNodeId)>>,
+    fn_metadata_attachment: Vec<(MetadataKindId, MetadataNodeId)>,
+}
+
+impl Function {
+    pub fn push_value_list(&mut self, value: Value) {
+        self.local_value_list.push(value);
+    }
+    /// In LLVM this is `InstID` variable, but it's not the same counter as instruction IDs for purpose of metadata attachments.
+    pub fn next_value_id(&self) -> ValueId {
+        self.first_local_value_list_id + self.local_value_list.len() as u32
+    }
+
+    pub fn local_value_by_id(&self, id: ValueId) -> Option<&Value> {
+        let local_id = id.checked_sub(self.first_local_value_list_id)?;
+        self.local_value_list.get(local_id as usize)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ValueKind {
+    Function,
+    GlobalVariable,
+    BasicBlock,
+    Instruction,
+    Constant,
+    Argument,
+    Metadata,
+    Other,
+}
+
+#[derive(Debug)]
+pub struct Value {
+    pub type_id: TypeId, // Type identifier
+    pub kind: ValueKind, // What kind of value this is
+}
+
+impl WIP {
+    fn parse_constants_block(
+        &mut self,
+        mut block: BlockIter<'_, 'input>,
+        mut func: Option<&mut Function>,
+    ) -> Result<(), Error> {
+        while let Some(record) = block.next_record()? {
+            let Some(con) = self.parse_constants_record(record)? else {
+                continue;
+            };
+            let type_id = con.get_type_id().unwrap_or_else(|| {
+                self.types
+                    .types
+                    .iter()
+                    .position(|t| matches!(t, Type::Void))
+                    .unwrap() as TypeId
+            });
+            if let Some(func) = &mut func {
+                func.push_value_list(Value {
+                    type_id,
+                    kind: ValueKind::Constant,
+                });
+            } else {
+                self.global_value_list.push(Value {
+                    type_id,
+                    kind: ValueKind::Constant,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_function_block(&mut self, mut block: BlockIter<'_, 'input>) -> Result<(), Error> {
+        let mut local_value_list = Vec::new();
+        let func = self.module_defined_functions.remove(0);
+
+        let fty = self.types.get_fn(func.ty).ok_or(Error::Other("bad fn"))?;
+
+        for (i, arg) in fty.param_types.clone().into_iter().enumerate() {
+            local_value_list.push(Value {
+                type_id: arg,
+                kind: ValueKind::Argument,
+            });
+        }
+        let mut func = Function {
+            record: func,
+            first_local_value_list_id: self.global_value_list.len() as _,
+            local_value_list,
+            instruction_counter: 0,
+            fn_metadata_attachment: Vec::new(),
+            inst_metadata_attachment: HashMap::new(),
+            metadata: Vec::new(),
+            basic_blocks: Vec::new(),
+        };
+        while let Some(b) = block.next()? {
+            match b {
+                BlockItem::Block(mut block) => {
+                    match BlockId::try_from(block.id as u8).unwrap() {
+                        BlockId::Constants => {
+                            self.parse_constants_block(block, Some(&mut func))?;
+                        }
+                        BlockId::Metadata => {
+                            self.parse_metadata_block(block, Some(&mut func))?;
+                        }
+                        BlockId::MetadataAttachment => {
+                            self.parse_metadata_attachment(block, &mut func)?;
+                        }
+                        BlockId::ValueSymtab => {
+                            while let Some(record) = block.next_record()? {
+                                vst.push(self.parse_value_symtab_record(record)?);
+                            }
+                        }
+                        block_id => {}
+                    };
+                }
+                BlockItem::Record(record) => {
+                    let record_id = record.id;
+                    if let Some(r) = self.parse_function_record(record, &mut func)? {
+                        let mut terminator = false;
+                        match r {
+                            TypedRecord::FunctionInst(inst) => {
+                                terminator = inst.is_terminator();
+                                let void_value = inst.is_void_type(&self.types);
+                                let inst_type_id = inst.ret_type_id(&self.types);
+                                let mut value_id = None;
+
+                                let index = func.instruction_counter;
+                                func.instruction_counter += 1;
+                                let mut restypeid = inst_type_id.map(|v| v as i64).unwrap_or(-1);
+                                if matches!(inst, Inst::FunctionInstCmp(_)) {
+                                    restypeid = -2;
+                                }
+                                let llvm_basic_type_id = inst_type_id
+                                    .and_then(|v| self.types.llvm_basic_type_id(v))
+                                    .map(|v| v as i64)
+                                    .unwrap_or(7);
+                                if !void_value {
+                                    value_id = Some(func.next_value_id());
+                                    func.push_value_list(Value {
+                                        kind: ValueKind::Instruction,
+                                        type_id: inst_type_id.expect("nonvoid"),
+                                    });
+                                }
+                                func.basic_blocks
+                                    .last_mut()
+                                    .unwrap()
+                                    .inst
+                                    .push(BBInstruction {
+                                        index,
+                                        value_id,
+                                        inst,
+                                    });
+                            }
+                            TypedRecord::FunctionDI(
+                                _meta @ (FunctionDI::DebugLoc(_)
+                                | FunctionDI::DebugRecordValue(_)
+                                | FunctionDI::DebugRecordDeclare(_)
+                                | FunctionDI::DebugLocAgain
+                                | FunctionDI::DebugRecordValueSimple(_)),
+                            ) => {}
+                            TypedRecord::FunctionDI(meta) => {
+                                func.push_value_list(Value {
+                                    kind: ValueKind::Metadata,
+                                    type_id: self
+                                        .types
+                                        .types
+                                        .iter()
+                                        .position(|t| matches!(t, Type::Metadata))
+                                        .unwrap()
+                                        as u32,
+                                });
+                            }
+                            _ => {}
+                        };
+
+                        if terminator {
+                            let bb = &mut func.basic_blocks;
+                            bb.push(BasicBlock { inst: Vec::new() });
+                        }
+                    }
+                }
+            }
+        }
+        self.functions.push(func);
+
+        Ok(())
+    }
+
+    /// pushValueAndType/getValueTypePair equivalent
+    #[track_caller]
+    fn value_and_type<'cursor>(
+        &mut self,
+        record: &mut RecordIter<'cursor, 'input>,
+        func: &mut Function,
+    ) -> Result<(ValueId, TypeId), Error> {
+        self.value_and_type_from_iter(record, func)
+    }
+
+    /// pushValueAndType/getValueTypePair equivalent
+    #[track_caller]
+    fn value_and_type_from_iter<'cursor>(
+        &mut self,
+        iter: &mut impl Iterator<Item = Result<u64, Error>>,
+        func: &mut Function,
+    ) -> Result<(ValueId, TypeId), Error> {
+        let relative_val_id = iter
+            .next()
+            .ok_or(Error::EndOfRecord)??
+            .try_into()
+            .map_err(|_| Error::ValueOverflow)?;
+        let next_value_id = func.next_value_id();
+
+        let val_id = next_value_id.checked_sub(relative_val_id).expect("nope");
+
+        // Forward references to values that haven't been processed yet need a type
+        let ty = if val_id >= next_value_id {
+            iter.next()
+                .ok_or(Error::EndOfRecord)??
+                .try_into()
+                .map_err(|_| Error::ValueOverflow)?
+        } else if let Some(v) = func
+            .local_value_by_id(val_id)
+            .or_else(|| self.global_value_list.get(val_id as usize))
+        {
+            // For backward references to global values, use the stored type if available
+            v.type_id
+        };
+
+        Ok((val_id, ty))
+    }
+
+    // pushValue/popValue equivalent
+    #[track_caller]
+    fn value_without_type<'cursor>(
+        &mut self,
+        record: &mut RecordIter<'cursor, 'input>,
+        func: &mut Function,
+    ) -> Result<ValueId, Error> {
+        let relative_val_id = record.u32()?;
+        let next_value_id = func.next_value_id();
+        let val_id = next_value_id.checked_sub(relative_val_id).expect("nope");
+        Ok(val_id)
+    }
+
+    #[track_caller]
+    fn value_signed<'cursor>(
+        &mut self,
+        record: &mut RecordIter<'cursor, 'input>,
+        func: &mut Function,
+    ) -> Result<ValueId, Error> {
+        let relative_val_id = record.i64()?;
+        let next_value_id = func.next_value_id();
+        let val_id = (next_value_id as i64 - relative_val_id).try_into().unwrap();
+        return Ok(val_id);
+    }
+
+    fn parse_module_record<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<Option<TypedRecord<'input>>, Error> {
+        Ok(Some(match ModuleCode::try_from(record.id as u8).unwrap() {
+            ModuleCode::Version => {
+                let version = record.u64()?;
+                assert!(version >= 2);
+                TypedRecord::ModuleVersion(ModuleVersionRecord { version })
+            }
+            ModuleCode::Triple => TypedRecord::ModuleTriple(ModuleTripleRecord {
+                triple: record.string()?.try_into().unwrap(),
+            }),
+            ModuleCode::Datalayout => TypedRecord::ModuleDataLayout(ModuleDataLayoutRecord {
+                datalayout: record.string()?.try_into().unwrap(),
+            }),
+            ModuleCode::Asm => TypedRecord::ModuleAsm(ModuleAsmRecord {
+                asm: record.string()?.try_into().unwrap(),
+            }),
+            ModuleCode::SectionName => TypedRecord::ModuleSectionName(ModuleSectionNameRecord {
+                section_name: record.string()?.try_into().unwrap(),
+            }),
+            ModuleCode::Deplib => TypedRecord::ModuleDepLib(ModuleDepLibRecord {
+                deplib_name: record.string()?.try_into().unwrap(),
+            }),
+            ModuleCode::GlobalVar => {
+                let name = record.range()?;
+                let type_id = record.u32()?;
+                let flags = record.u32()?;
+                let init_id = record.nzu64()?;
+                let linkage = Linkage::try_from(record.u8()?).unwrap();
+                let alignment = record.nzu32()?;
+                let section = record.nzu32()?;
+                let var = if !record.is_empty() {
+                    ModuleGlobalVarRecord {
+                        name,
+                        type_id,
+                        flags,
+                        init_id,
+                        linkage,
+                        alignment,
+                        section,
+                        visibility: record.u8()?,
+                        thread_local: record.u8()?,
+                        unnamed_addr: record.nzu8()?,
+                        dll_storage_class: DllStorageClass::try_from(record.u8()?).unwrap(),
+                        comdat: record.nzu64()?,
+                        attributes: record.nzu32()?,
+                        dso_local: record.bool()?,
+                        global_sanitizer: record.nzu32()?,
+                        partition: record.range()?,
+                        code_model: record.u32()?,
+                    }
+                } else {
+                    ModuleGlobalVarRecord {
+                        name,
+                        type_id,
+                        flags,
+                        init_id,
+                        linkage,
+                        alignment,
+                        section,
+                        visibility: 0,
+                        thread_local: 0,
+                        unnamed_addr: None,
+                        dll_storage_class: DllStorageClass::Default,
+                        comdat: None,
+                        attributes: None,
+                        dso_local: false,
+                        global_sanitizer: None,
+                        partition: 0..0,
+                        code_model: 0,
+                    }
+                };
+                assert!(self.functions.is_empty());
+                self.global_value_list.push(Value {
+                    type_id: type_id,
+                    kind: ValueKind::GlobalVariable,
+                });
+                TypedRecord::ModuleGlobalVar(var)
+            }
+            ModuleCode::Function => {
+                assert!(record.len() >= 18);
+                let fun = ModuleFunctionRecord {
+                    name: record.range()?,
+                    ty: record.u32()?,
+                    calling_conv: CallConv::try_from(record.u8()?).unwrap(),
+                    is_proto: record.bool()?,
+                    linkage: Linkage::try_from(record.u8()?).unwrap(),
+                    attributes: record.nzu32()?,
+                    alignment: record.nzu32()?,
+                    section: record.nzu32()?,
+                    visibility: record.u8()?,
+                    gc: record.nzu64()?,
+                    unnamed_addr: record.nzu8()?,
+                    prologue_data: record.nzu64()?,
+                    dll_storage_class: DllStorageClass::try_from(record.u8()?).unwrap(),
+                    comdat: record.nzu64()?,
+                    prefix_data: record.nzu64()?,
+                    personality_fn: record.nzu64()?,
+                    dso_local: record.bool()?,
+                    address_space: record.u64()?,
+                    partition_name: record.range()?,
+                };
+                assert!(self.functions.is_empty());
+                self.global_value_list.push(Value {
+                    type_id: fun.ty,
+                    kind: ValueKind::Function,
+                });
+                if !fun.is_proto {
+                    self.module_defined_functions.push(fun);
+                    return Ok(None);
+                }
+                TypedRecord::ModuleFunction(fun)
+            }
+            ModuleCode::AliasOld => TypedRecord::ModuleAlias(ModuleAliasRecord {
+                name: record.range()?,
+                alias_type: record.u32()?,
+                aliasee_val: record.u32()?,
+                linkage: record.u64()?,
+                visibility: record.u8()?,
+                dll_storage_class: DllStorageClass::try_from(record.u8()?).unwrap(),
+                threadlocal: record.u8()?,
+                unnamed_addr: record.nzu8()?,
+                preemption_specifier: record.u64()?,
+            }),
+            ModuleCode::GCName => TypedRecord::ModuleGCName(ModuleGCNameRecord {
+                gc_name: record.string()?.try_into().unwrap(),
+            }),
+            ModuleCode::VstOffset => {
+                return Ok(None);
+            }
+            ModuleCode::SourceFilename => {
+                TypedRecord::ModuleSourceFilename(record.string()?.try_into().unwrap())
+            }
+            ModuleCode::Hash => {
+                TypedRecord::ModuleHash(ModuleHashRecord(std::array::from_fn(|_| {
+                    record.u32().unwrap_or_default()
+                })))
+            }
+            _ => self.parse_generic_record(record)?,
+        }))
+    }
+
+    fn parse_attributes_record<'cursor>(
+        &mut self,
+        record: RecordIter<'cursor, 'input>,
+    ) -> Result<TypedRecord<'input>, Error> {
+        Ok(TypedRecord::Attributes(
+            record.collect::<Result<Vec<_>, _>>().unwrap(),
+        ))
+    }
+
+    fn parse_constants_record<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<Option<ConstantRecord>, Error> {
+        let id = ConstantsCodes::try_from(record.id as u8).unwrap();
+        let ty = self.constants_current_type.unwrap_or_else(|| panic!());
+        let con = match id {
+            ConstantsCodes::Settype => {
+                self.constants_current_type = Some(record.u32()?);
+                return Ok(None);
+            }
+            ConstantsCodes::Null => ConstantRecord::ConstantNull,
+            ConstantsCodes::Undef => ConstantRecord::ConstantUndef,
+            ConstantsCodes::Integer => ConstantRecord::ConstantInteger(ConstantInteger {
+                ty,
+                value: record.i64()?,
+            }),
+            ConstantsCodes::WideInteger => {
+                ConstantRecord::ConstantWideInteger(ConstantWideInteger {
+                    ty,
+                    values: record.collect::<Result<Vec<_>, _>>()?,
+                })
+            }
+            ConstantsCodes::Float => ConstantRecord::ConstantFloat(ConstantFloat {
+                ty,
+                value: f64::from_bits(record.u64()?),
+            }),
+            ConstantsCodes::Aggregate => ConstantRecord::ConstantAggregate(ConstantAggregate {
+                ty,
+                values: record.collect::<Result<Vec<_>, _>>()?,
+            }),
+            ConstantsCodes::String | ConstantsCodes::Data => {
+                ConstantRecord::ConstantString(ConstantString {
+                    ty,
+                    value: record.string()?,
+                })
+            }
+            ConstantsCodes::CString => ConstantRecord::ConstantCString(ConstantCString {
+                ty,
+                value: record.string()?.try_into().unwrap(),
+            }),
+            ConstantsCodes::BinOp => ConstantRecord::ConstantBinaryOp(ConstantBinaryOp {
+                ty,
+                opcode: record.try_from::<u8, _>()?,
+                lhs: record.u32()?,
+                rhs: record.u32()?,
+                flags: record.next()?.unwrap_or(0) as u8,
+            }),
+            ConstantsCodes::Cast => ConstantRecord::ConstantCast(ConstantCast {
+                opcode: record.try_from::<u8, _>()?,
+                ty: record.u32()?,
+                operand: record.u32()?,
+            }),
+            id @ (ConstantsCodes::Gep | ConstantsCodes::GepWithInrange) => {
+                let base_type = record.u32()?;
+                let flags = record.u8()?;
+                let inrange = if id == ConstantsCodes::GepWithInrange {
+                    record.nzu64()?
+                } else {
+                    None
+                };
+                let mut operands = Vec::with_capacity(record.len() / 2);
+                while record.len() >= 2 {
+                    operands.push((record.u32()?, record.u32()?));
+                }
+                ConstantRecord::ConstantGEP(ConstantGEP {
+                    ty,
+                    base_type,
+                    flags,
+                    inrange,
+                    operands,
+                })
+            }
+            ConstantsCodes::Select => ConstantRecord::ConstantSelect(ConstantSelect {
+                ty,
+                condition: record.u64()?,
+                true_value: record.u64()?,
+                false_value: record.u64()?,
+            }),
+            ConstantsCodes::ExtractElt => {
+                ConstantRecord::ConstantExtractElement(ConstantExtractElement {
+                    operand_ty: record.u32()?,
+                    operand_val: record.u32()?,
+                    index_ty: record.u32()?,
+                    index_val: record.u32()?,
+                })
+            }
+            ConstantsCodes::InsertElt => {
+                ConstantRecord::ConstantInsertElement(ConstantInsertElement {
+                    ty,
+                    operand_type: record.u32()?,
+                    vector: record.u64()?,
+                    element: record.u64()?,
+                    index: record.u64()?,
+                })
+            }
+            ConstantsCodes::ShuffleVec => {
+                ConstantRecord::ConstantShuffleVector(ConstantShuffleVector {
+                    ty,
+                    vector1: record.u64()?,
+                    vector2: record.u64()?,
+                    mask: record.u64()?,
+                })
+            }
+            ConstantsCodes::Cmp => ConstantRecord::ConstantCompare(ConstantCompare {
+                ty,
+                operand_type: record.u32()?,
+                lhs: record.u64()?,
+                rhs: record.u64()?,
+                predicate: record.u8()?,
+            }),
+            ConstantsCodes::BlockAddress => {
+                ConstantRecord::ConstantBlockAddress(ConstantBlockAddress {
+                    ty,
+                    function: record.u64()?,
+                    block: record.u64()?,
+                })
+            }
+            ConstantsCodes::InlineAsm => ConstantRecord::ConstantInlineASM(ConstantInlineASM {
+                ty,
+                function_type: record.u32()?,
+                flags: record.u8()?,
+                asm: record.string()?.try_into().unwrap(),
+                constraints: record.string()?.try_into().unwrap(),
+            }),
+            ConstantsCodes::Poison => ConstantRecord::ConstantPoison,
+            ConstantsCodes::DsoLocalEquivalent => {
+                ConstantRecord::ConstantDSOLocalEquivalent(ConstantDSOLocalEquivalent {
+                    ty,
+                    gv_type: record.u32()?,
+                    gv: record.u64()?,
+                })
+            }
+            ConstantsCodes::NoCfiValue => ConstantRecord::ConstantNoCFI(ConstantNoCFI {
+                ty,
+                function_type: record.u32()?,
+                function: record.u64()?,
+            }),
+            ConstantsCodes::PtrAuth => ConstantRecord::ConstantPtrAuth(ConstantPtrAuth {
+                ty,
+                pointer: record.u64()?,
+                key: record.u64()?,
+                discriminator: record.u64()?,
+                address_discriminator: record.u64()?,
+            }),
+            ConstantsCodes::ShufVecEx => todo!(),
+            ConstantsCodes::InboundsGep => todo!(),
+            ConstantsCodes::UnOp => todo!(),
+            other => unimplemented!("{other:?} constant"),
+        };
+        Ok(Some(con))
+    }
+
+    fn parse_function_record<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+        func: &mut Function,
+    ) -> Result<Option<TypedRecord<'input>>, Error> {
+        Ok(Some(
+            match FunctionCode::try_from(record.id as u8).unwrap() {
+                FunctionCode::DeclareBlocks => {
+                    let num = record.u64()?;
+                    let bb = &mut func.basic_blocks;
+                    bb.reserve_exact(num as _);
+                    if bb.is_empty() {
+                        bb.push(BasicBlock { inst: Vec::new() });
+                    }
+                    return Ok(None);
+                }
+                // this is still relevant, in addition to metadata
+                FunctionCode::DebugLocAgain => TypedRecord::FunctionDI(FunctionDI::DebugLocAgain),
+                // this is still relevant, in addition to metadata
+                FunctionCode::DebugLoc => {
+                    TypedRecord::FunctionDI(FunctionDI::DebugLoc(FunctionDebugLoc {
+                        line: record.u64()?,
+                        column: record.u64()?,
+                        scope_id: record.u64()?,
+                        ia_val: record.u32()?,
+                        implicit_code: record.u64()?,
+                    }))
+                }
+                FunctionCode::OperandBundle => {
+                    TypedRecord::FunctionOperandBundle(FunctionOperandBundle {
+                        tag_id: record.u64()?,
+                        values_types: {
+                            let mut tmp = Vec::new();
+                            while !record.is_empty() {
+                                tmp.push(self.value_and_type(&mut record, func)?);
+                            }
+                            tmp
+                        },
+                    })
+                }
+                FunctionCode::BlockaddrUsers => {
+                    TypedRecord::FunctionBlockAddrUsers(FunctionBlockAddrUsers(
+                        record
+                            .map(|r| r.map(|u| u as u32))
+                            .collect::<Result<Vec<_>, _>>()?,
+                    ))
+                }
+                FunctionCode::DebugRecordValue => TypedRecord::FunctionDI(
+                    FunctionDI::DebugRecordValue(FunctionDebugRecordValue {
+                        di_location: record.u64()?,
+                        di_local_variable: record.u64()?,
+                        di_expression: record.u64()?,
+                        value_as_metadata: record.u64()?,
+                    }),
+                ),
+                FunctionCode::DebugRecordDeclare => TypedRecord::FunctionDI(
+                    FunctionDI::DebugRecordDeclare(FunctionDebugRecordDeclare {
+                        di_location: record.u64()?,
+                        di_local_variable: record.u64()?,
+                        di_expression: record.u64()?,
+                        value_as_metadata: record.u64()?,
+                    }),
+                ),
+                FunctionCode::DebugRecordAssign => TypedRecord::FunctionDI(
+                    FunctionDI::DebugRecordAssign(FunctionDebugRecordAssign {
+                        di_location: record.u64()?,
+                        di_local_variable: record.u64()?,
+                        di_expression: record.u64()?,
+                        value_as_metadata: record.u64()?,
+                        di_assign_id: record.u64()?,
+                        di_expression_addr: record.u64()?,
+                        value_as_metadata_addr: record.u64()?,
+                    }),
+                ),
+                FunctionCode::DebugRecordValueSimple => {
+                    return Ok(Some(TypedRecord::FunctionDI(
+                        FunctionDI::DebugRecordValueSimple(FunctionDebugRecordValueSimple {
+                            di_location: record.u64()?,
+                            di_local_variable: record.u64()?,
+                            di_expression: record.u64()?,
+                            value: record.u64()?,
+                        }),
+                    )));
+                }
+                FunctionCode::DebugRecordLabel => TypedRecord::FunctionDI(
+                    FunctionDI::DebugRecordLabel(FunctionDebugRecordLabel {
+                        di_location: record.u64()?,
+                        di_label: record.u64()?,
+                    }),
+                ),
+                _ => {
+                    let inst = match FunctionCode::try_from(record.id as u8).unwrap() {
+                        FunctionCode::BinOp => {
+                            let (operand_val, operand_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            let operand2_val = self.value_without_type(&mut record, func)?;
+
+                            let opcode = BinOpcode::try_from(record.u8()?)
+                                .map_err(|_| Error::Other("bad binop"))?;
+                            let op_vals = [operand_val, operand2_val];
+                            let flags = record.next()?.unwrap_or(0) as u8;
+                            if record.len() >= 4 {
+                                // uint8_t Flag
+                            }
+                            let inst = Inst::FunctionInstBinOp(FunctionInstBinOp {
+                                opcode,
+                                op_vals,
+                                operand_ty,
+                                flags,
+                            });
+                            inst
+                        }
+                        FunctionCode::Cast => {
+                            let (operand_val, operand_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            let inst = Inst::FunctionInstCast(FunctionInstCast {
+                                operand_ty,
+                                operand_val,
+                                result_ty: record.u32()?,
+                                opcode: CastOpcode::try_from(record.u8()?)
+                                    .map_err(|_| Error::Other("bad cast"))?,
+                            });
+                            inst
+                        }
+                        FunctionCode::ExtractElt => {
+                            Inst::FunctionInstExtractElt(FunctionInstExtractElt {
+                                vector_ty: record.u32()?,
+                                vector_val: record.u32()?,
+                                index_val: record.u32()?,
+                            })
+                        }
+                        FunctionCode::InsertElt => {
+                            Inst::FunctionInstInsertElt(FunctionInstInsertElt {
+                                vector_ty: record.u32()?,
+                                vector_val: record.u32()?,
+                                element_val: record.u32()?,
+                                index_val: record.u32()?,
+                            })
+                        }
+                        FunctionCode::ShuffleVec => {
+                            Inst::FunctionInstShuffleVec(FunctionInstShuffleVec {
+                                vector_ty: record.u32()?,
+                                lhs_val: record.u32()?,
+                                rhs_val: record.u32()?,
+                                mask_val: record.u32()?,
+                            })
+                        }
+                        FunctionCode::Ret => {
+                            let (return_val, return_ty) = if !record.is_empty() {
+                                self.value_and_type(&mut record, func)
+                                    .map(|(a, b)| (Some(a), Some(b)))?
+                            } else {
+                                let fty = self
+                                    .types
+                                    .get_fn(func.record.ty)
+                                    .ok_or(Error::Other("bad fn"))?;
+                                (None, fty.ret_ty)
+                            };
+                            Inst::FunctionInstRet(FunctionInstRet {
+                                return_ty,
+                                return_val,
+                            })
+                        }
+                        FunctionCode::Br => {
+                            // this is bb index, not val_id
+                            let bb1 = record.u32()?;
+                            Inst::FunctionInstBr(if !record.is_empty() {
+                                FunctionInstBr::Cond {
+                                    true_bb: bb1,
+                                    false_bb: record.u32()?,
+                                    condition_val: self.value_without_type(&mut record, func)?,
+                                }
+                            } else {
+                                FunctionInstBr::Uncond { dest_bb: bb1 }
+                            })
+                        }
+                        FunctionCode::Switch => {
+                            let condition_ty = record.u32()?;
+                            let condition_val = self.value_without_type(&mut record, func)?;
+                            let default_bb = record.u32()?;
+                            let num_cases = record.len() / 2;
+                            let mut cases = Vec::with_capacity(num_cases);
+                            for _ in 0..num_cases {
+                                let value = record.u32()?;
+                                let target_bb = record.u32()?;
+                                cases.push((value, target_bb));
+                            }
+                            Inst::FunctionInstSwitch(FunctionInstSwitch {
+                                condition_ty,
+                                condition_val,
+                                default_bb,
+                                cases,
+                            })
+                        }
+                        // can be void
+                        FunctionCode::Invoke => Inst::FunctionInstInvoke(FunctionInstInvoke {
+                            attr: record.u64()?,
+                            callee_val: record.u32()?, // val id
+                            normal_bb: record.u32()?,  // not val id
+                            unwind_bb: record.u32()?,
+                            function_ty: record.u32()?,
+                            args: record.collect::<Result<Vec<_>, _>>()?, // val id
+                        }),
+                        FunctionCode::Unreachable => {
+                            assert!(record.is_empty());
+                            Inst::FunctionInstUnreachable
+                        }
+                        FunctionCode::Phi => {
+                            let ty = record.u32()?;
+                            let mut incoming = Vec::new();
+                            while record.len() >= 2 {
+                                let incoming_val = self.value_signed(&mut record, func)?;
+                                let incoming_bb = record.u32()?;
+                                incoming.push((incoming_val, incoming_bb));
+                            }
+                            let flags = record.next()?.unwrap_or(0) as u8;
+                            Inst::FunctionInstPhi(FunctionInstPhi {
+                                ty,
+                                incoming,
+                                flags,
+                            })
+                        }
+                        FunctionCode::Alloca => Inst::FunctionInstAlloca(FunctionInstAlloca {
+                            result_ty: record.u32()?,
+                            array_size_ty: record.u32()?,
+                            array_size_val: record.u32()?,
+                            alignment: record.u64()?,
+                        }),
+                        id @ (FunctionCode::Load | FunctionCode::LoadAtomic) => {
+                            let is_atomic = matches!(id, FunctionCode::LoadAtomic);
+                            let (ptr_val, ptr_ty) = self.value_and_type(&mut record, func)?;
+                            Inst::FunctionInstLoad(FunctionInstLoad {
+                                ptr_ty,
+                                ptr_val,
+                                ret_ty: record.u32()?,
+                                alignment: record.u64()?,
+                                is_volatile: record.bool()?,
+                                atomic: if is_atomic {
+                                    Some((record.try_from::<u8, _>()?, record.u64()?))
+                                } else {
+                                    None
+                                },
+                            })
+                        }
+                        FunctionCode::VaArg => Inst::FunctionInstVAArg(FunctionInstVAArg {
+                            valist_ty: record.u32()?,
+                            valist_val: record.u32()?,
+                            result_ty: record.u32()?,
+                        }),
+                        id @ (FunctionCode::Store
+                        | FunctionCode::StoreOld
+                        | FunctionCode::StoreAtomic
+                        | FunctionCode::StoreAtomicOld) => {
+                            let is_atomic = matches!(
+                                id,
+                                FunctionCode::StoreAtomic | FunctionCode::StoreAtomicOld
+                            );
+                            let (ptr_val, ptr_ty) = self.value_and_type(&mut record, func)?;
+                            let (stored_val, stored_ty) = self.value_and_type(&mut record, func)?;
+                            let alignment = record.u64()?;
+                            let is_volatile = record.bool()?;
+
+                            Inst::FunctionInstStore(FunctionInstStore {
+                                ptr_ty,
+                                ptr_val,
+                                stored_val,
+                                stored_ty,
+                                alignment,
+                                is_volatile,
+                                atomic: if is_atomic {
+                                    Some((record.try_from::<u8, _>()?, record.u64()?))
+                                } else {
+                                    None
+                                },
+                            })
+                        }
+                        FunctionCode::ExtractVal => {
+                            let (val, ty) = self.value_and_type(&mut record, func)?;
+                            Inst::FunctionInstExtractVal(FunctionInstExtractVal {
+                                ty,
+                                val,
+                                operands: record.collect::<Result<Vec<_>, _>>()?,
+                            })
+                        }
+                        FunctionCode::InsertVal => {
+                            let (aggregate_val, aggregate_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            let (element_val, element_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            let indices = record.array()?;
+                            Inst::FunctionInstInsertVal(FunctionInstInsertVal {
+                                aggregate_ty,
+                                aggregate_val,
+                                element_ty,
+                                element_val,
+                                indices,
+                            })
+                        }
+                        FunctionCode::Cmp2 | FunctionCode::Cmp => {
+                            let (val_id, ty) = self.value_and_type(&mut record, func)?;
+                            Inst::FunctionInstCmp(FunctionInstCmp {
+                                operand_ty: ty,
+                                lhs_val: val_id,
+                                rhs_val: record.u32()?,
+                                predicate: record.u64()?,
+                                flags: record.next()?.unwrap_or(0),
+                            })
+                        }
+                        FunctionCode::SelectOld => {
+                            // obsolete opcode
+                            let mut condition_ty = None;
+                            for (i, t) in self.types.types.iter().enumerate() {
+                                if matches!(t, Type::Integer { width: n } if n.get() == 1) {
+                                    condition_ty = Some(i as u32);
+                                    break;
+                                }
+                            }
+                            let (true_val, result_ty) = self.value_and_type(&mut record, func)?;
+                            let false_val = self.value_without_type(&mut record, func)?;
+                            let condition_val = self.value_without_type(&mut record, func)?;
+                            Inst::FunctionInstSelect(FunctionInstSelect {
+                                result_ty,
+                                condition_ty: condition_ty.unwrap(),
+                                condition_val,
+                                true_val,
+                                false_val,
+                                flags: 0,
+                            })
+                        }
+                        FunctionCode::Vselect => {
+                            let (true_val, result_ty) = self.value_and_type(&mut record, func)?;
+                            let false_val = self.value_without_type(&mut record, func)?;
+                            let (condition_val, condition_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            let flags = record.next()?.unwrap_or(0) as u8;
+                            let inst = Inst::FunctionInstSelect(FunctionInstSelect {
+                                result_ty,
+                                true_val,
+                                false_val,
+                                condition_ty,
+                                condition_val,
+                                flags,
+                            });
+                            dbg!(inst)
+                        }
+                        FunctionCode::IndirectBr => {
+                            Inst::FunctionInstIndirectBr(FunctionInstIndirectBr {
+                                ptr_ty: record.u32()?,
+                                address_val: self.value_without_type(&mut record, func)?,
+                                destinations: record
+                                    .map(|v| v.map(|v| v as u32))
+                                    .collect::<Result<Vec<_>, _>>()?,
+                            })
+                        }
+                        // can be void
+                        FunctionCode::Call => {
+                            let attr = record.nzu32()?;
+                            let calling_conv_flags = record.u64()?;
+                            let math_flags = if (calling_conv_flags >> 17) & 1 != 0 {
+                                record.u8()?
+                            } else {
+                                0
+                            };
+                            let explicit_type = (calling_conv_flags >> 15) & 1 != 0;
+
+                            let mut function_ty = if explicit_type { record.u32()? } else { 0 };
+                            let (callee_val, callee_ty) = self.value_and_type(&mut record, func)?;
+                            if !explicit_type {
+                                function_ty = callee_ty;
+                            }
+
+                            let _fty = self
+                                .types
+                                .get_fn(function_ty)
+                                .ok_or(Error::Other("bad fn"))?;
+
+                            Inst::FunctionInstCall(FunctionInstCall {
+                                attr,
+                                calling_conv: CallConv::from_flags(calling_conv_flags).unwrap(),
+                                math_flags,
+                                function_ty,
+                                callee_val,
+                                callee_ty,
+                                args: self.function_args(function_ty, &mut record, func)?,
+                            })
+                        }
+                        FunctionCode::Fence => Inst::FunctionInstFence(FunctionInstFence {
+                            ordering: record.try_from::<u8, _>()?,
+                            synch_scope: record.u64()?,
+                        }),
+                        FunctionCode::Resume => {
+                            let (exception_val, exception_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            Inst::FunctionInstResume(FunctionInstResume {
+                                exception_val,
+                                exception_ty,
+                            })
+                        }
+                        FunctionCode::GepOld => unimplemented!(),
+                        FunctionCode::Gep => {
+                            let flags = record.u8()?;
+                            let source_type = record.u32()?;
+
+                            // this is weird format with vbr6 array not vbr6 fields
+                            let record_payload = record.array()?;
+                            let mut record_payload = record_payload.into_iter().map(Ok);
+
+                            let (base_ptr, base_ty) =
+                                self.value_and_type_from_iter(&mut record_payload, func)?;
+
+                            let mut operands = Vec::with_capacity(record.len() / 2);
+                            while record_payload.len() > 0 {
+                                operands.push(
+                                    self.value_and_type_from_iter(&mut record_payload, func)?,
+                                );
+                            }
+                            let inst = Inst::FunctionInstGep(FunctionInstGep {
+                                base_ptr,
+                                base_ty,
+                                flags,
+                                source_type,
+                                operands,
+                            });
+                            inst
+                        }
+
+                        FunctionCode::Cmpxchg | FunctionCode::CmpxchgOld => {
+                            let (ptr_val, ptr_ty) = self.value_and_type(&mut record, func)?;
+                            let (cmp_val, cmp_ty) = self.value_and_type(&mut record, func)?;
+                            let new_val = self.value_without_type(&mut record, func)?;
+                            Inst::FunctionInstCmpXchg(FunctionInstCmpXchg {
+                                ptr_ty,
+                                ptr_val,
+                                cmp_val,
+                                cmp_ty,
+                                new_val,
+                                is_volatile: record.bool()?,
+                                success_ordering: record.try_from::<u8, _>()?,
+                                synch_scope: record.u64()?,
+                                failure_ordering: record.try_from::<u8, _>()?,
+                                is_weak: record.bool()?,
+                                alignment: record.u64()?,
+                            })
+                        }
+                        FunctionCode::LandingPad | FunctionCode::LandingPadOld => {
+                            let result_ty = record.u32()?;
+                            let is_cleanup = record.u32()?;
+                            let num_clauses = record.u64()? as usize;
+                            let mut clauses = Vec::with_capacity(num_clauses);
+                            for _ in 0..num_clauses {
+                                // catch or filter
+                                clauses
+                                    .push((record.u32()?, self.value_and_type(&mut record, func)?));
+                            }
+                            Inst::FunctionInstLandingPad(FunctionInstLandingPad {
+                                result_ty,
+                                is_cleanup,
+                                clauses,
+                            })
+                        }
+                        FunctionCode::CatchRet => {
+                            Inst::FunctionInstCatchRet(FunctionInstCatchRet {
+                                catch_pad: record.u32()?,
+                                successor: record.u32()?,
+                            })
+                        }
+                        id @ (FunctionCode::CatchPad | FunctionCode::CleanupPad) => {
+                            let parent_pad = self.value_without_type(&mut record, func)?;
+                            let num_args = record.u64()? as usize;
+                            let mut args = Vec::with_capacity(num_args);
+                            for _ in 0..num_args {
+                                args.push(self.value_and_type(&mut record, func)?);
+                            }
+                            if matches!(id, FunctionCode::CatchPad) {
+                                Inst::FunctionInstCatchPad(FunctionInstCatchPad {
+                                    parent_pad,
+                                    args,
+                                })
+                            } else {
+                                Inst::FunctionInstCleanupPad(FunctionInstCleanupPad {
+                                    parent_pad,
+                                    args,
+                                })
+                            }
+                        }
+                        FunctionCode::CatchSwitch => {
+                            let parent_pad = self.value_without_type(&mut record, func)?;
+                            let num_args = record.u64()? as usize;
+                            let mut args = Vec::with_capacity(num_args);
+                            for _ in 0..num_args {
+                                args.push(record.u32()?);
+                            }
+                            Inst::FunctionInstCatchSwitch(FunctionInstCatchSwitch {
+                                parent_pad,
+                                args,
+                                unwind_dest: record.next()?.map(|u| u as ValueId),
+                            })
+                        }
+                        FunctionCode::UnOp => {
+                            let (operand_val, operand_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            Inst::FunctionInstUnOp(FunctionInstUnOp {
+                                operand_ty,
+                                operand_val,
+                                opcode: record.u8()?,
+                                flags: record.next()?.unwrap_or(0) as u8,
+                            })
+                        }
+                        FunctionCode::CallBr => {
+                            let attr = record.u64()?;
+                            let calling_conv_flags = record.u64()?;
+                            let explicit_type = (calling_conv_flags >> 15) & 1 != 0;
+                            let mut function_ty = if explicit_type { record.u32()? } else { 0 };
+                            let (callee_val, callee_ty) = self.value_and_type(&mut record, func)?;
+                            if !explicit_type {
+                                function_ty = callee_ty;
+                            }
+                            let _ty = self
+                                .types
+                                .get_fn(function_ty)
+                                .ok_or(Error::Other("bad fn"))?;
+                            Inst::FunctionInstCallBr(FunctionInstCallBr {
+                                attr,
+                                calling_conv: CallConv::from_flags(calling_conv_flags).unwrap(),
+                                normal_bb: record.u32()?,
+                                indirect_bb: (0..record.u64()?)
+                                    .map(|_| record.u32())
+                                    .collect::<Result<Vec<_>, _>>()?,
+                                function_ty,
+                                callee_val,
+                                callee_ty,
+                                args: self.function_args(function_ty, &mut record, func)?,
+                            })
+                        }
+                        FunctionCode::Freeze => {
+                            let (operand_val, operand_ty) =
+                                self.value_and_type(&mut record, func)?;
+                            Inst::FunctionInstFreeze(FunctionInstFreeze {
+                                operand_ty,
+                                operand_val,
+                            })
+                        }
+                        FunctionCode::AtomicRmw | FunctionCode::AtomicRmwOld => {
+                            let (ptr_val, ptr_ty) = self.value_and_type(&mut record, func)?;
+                            let (stored_val, val_ty) = self.value_and_type(&mut record, func)?;
+                            Inst::FunctionInstAtomicRmw(FunctionInstAtomicRmw {
+                                ptr_ty,
+                                ptr_val,
+                                val_ty,
+                                stored_val,
+                                operation: record.u64()?,
+                                is_volatile: record.bool()?,
+                                ordering: record.try_from::<u8, _>()?,
+                                synch_scope: record.u64()?,
+                                alignment: record.u64()?,
+                            })
+                        }
+                        _ => unimplemented!(),
+                    };
+                    TypedRecord::FunctionInst(inst)
+                }
+            },
+        ))
+    }
+
+    fn parse_identification_record<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<TypedRecord<'input>, Error> {
+        match record.id {
+            1 => Ok(TypedRecord::IdentificationString(
+                record.string()?.try_into().unwrap(),
+            )),
+            2 => Ok(TypedRecord::IdentificationEpoch(
+                record.next().unwrap().unwrap(),
+            )),
+            _ => self.parse_generic_record(record),
+        }
+    }
+
+    fn parse_global_value_summary<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<TypedRecord<'input>, Error> {
+        match GlobalValueSummaryCode::try_from(record.id as u8).unwrap() {
+            GlobalValueSummaryCode::PerModuleGlobalvarInitRefs => Ok(
+                TypedRecord::PerModuleGlobalVarInitRefs(PerModuleGlobalVarInitRefsRecord {
+                    value_id: record.u32()?,
+                    flags: record.u64()?,
+                    init_refs: record.array()?.into_iter().map(|u| u as u32).collect(),
+                }),
+            ),
+            _ => Ok(self.parse_generic_record(record)?),
+        }
+    }
+
+    fn parse_operand_bundle_tag<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<TypedRecord<'input>, Error> {
+        Ok(TypedRecord::OperandBundleTag(
+            record.string()?.try_into().unwrap(),
+        ))
+    }
+
+    fn parse_symtab_blob<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<TypedRecord<'input>, Error> {
+        Ok(TypedRecord::SymtabBlob(SymtabBlobRecord {
+            blob: record.blob()?,
+        }))
+    }
+
+    fn parse_value_symtab_record<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<ValueSymtab, Error> {
+        Ok(match ValueSymtabCode::try_from(record.id as u8).unwrap() {
+            ValueSymtabCode::Entry => ValueSymtab::Entry(ValueSymtabEntryRecord {
+                value_id: record.u32()?,
+                name: record.string()?.try_into().unwrap(),
+            }),
+            ValueSymtabCode::BbEntry => ValueSymtab::Bbentry(ValueSymtabBbentryRecord {
+                id: record.u32()?,
+                name: record.string()?.try_into().unwrap(),
+            }),
+            ValueSymtabCode::FnEntry => {
+                // unused
+                ValueSymtab::Fnentry(ValueSymtabFnentryRecord {
+                    linkage_value_id: record.u32()?,
+                    function_offset: record.u64()?,
+                    name: record.string().map(|e| String::try_from(e).unwrap()).ok(),
+                })
+            }
+            // Obsolete
+            ValueSymtabCode::CombinedEntry => {
+                ValueSymtab::CombinedEntry(ValueSymtabCombinedEntryRecord {
+                    linkage_value_id: record.u32()?,
+                    refguid: record.u64()?,
+                })
+            }
+            _ => unimplemented!(),
+        })
+    }
+
+    fn parse_sync_scope_name<'cursor>(
+        &mut self,
+        mut record: RecordIter<'cursor, 'input>,
+    ) -> Result<TypedRecord<'input>, Error> {
+        Ok(TypedRecord::SyncScopeName(
+            record.string()?.try_into().unwrap(),
+        ))
+    }
+
+    fn parse_generic_record<'cursor>(
+        &mut self,
+        record: RecordIter<'cursor, 'input>,
+    ) -> Result<TypedRecord<'input>, Error> {
+        Ok(TypedRecord::Generic(
+            record.id,
+            record.collect::<Result<Vec<_>, _>>()?,
+        ))
+    }
+
+    //  [attr_index, fnty, callee, arg0... argN, flags].
+    //  this only gets arg0..argN
+    fn function_args<'cursor>(
+        &mut self,
+        function_ty: TypeId,
+        record: &mut RecordIter<'cursor, 'input>,
+        func: &mut Function,
+    ) -> Result<Vec<CallArg>, Error> {
+        let ty = self
+            .types
+            .get_fn(function_ty)
+            .ok_or(Error::Other("bad function type"))?;
+
+        let arg_types = ty.param_types.as_slice();
+        let mut args = Vec::with_capacity(arg_types.len());
+        for &arg_ty in arg_types {
+            let ty = self.types.get(arg_ty).ok_or(Error::Other("bad arg"))?;
+            let id = record.u32()?;
+            args.push(if matches!(ty, Type::Label) {
+                CallArg::Label(id)
+            } else {
+                CallArg::Val(id)
+            });
+        }
+        if ty.vararg {
+            for _ in 0..record.len() {
+                let (v_op, v_ty) = self.value_and_type(record, func)?;
+                args.push(CallArg::Var(v_op, v_ty));
+            }
+        }
+        Ok(args)
+    }
+
+    pub fn parse_param_attr_grp_record(
+        &mut self,
+        mut record: RecordIter<'_, 'input>,
+    ) -> Result<AttributeGroupEntry, Error> {
+        let group_id = record.u64()?;
+        let index = record.u64()?;
+        let mut attributes = Vec::new();
+
+        while let Some(id) = record.next()? {
+            attributes.push(match ParamAttrGrpCodes::try_from(id as u8).unwrap() {
+                ParamAttrGrpCodes::EnumAttr => {
+                    // Enum attribute (e.g., AlwaysInline, NoInline)
+                    Attribute::AttrKind(AttrKind::try_from(record.u8()?).unwrap())
+                }
+                ParamAttrGrpCodes::IntAttr => {
+                    // Integer attribute (e.g., Alignment, StackAlignment)
+                    let kind = AttrKind::try_from(record.u8()?).unwrap();
+                    let value = record.u64()?;
+                    Attribute::Int { kind, value }
+                }
+                id @ (ParamAttrGrpCodes::StringAttr | ParamAttrGrpCodes::StringAttrWithValue) => {
+                    // String attribute
+                    let key = record.zstring()?;
+                    let mut value = None;
+                    if matches!(id, ParamAttrGrpCodes::StringAttrWithValue) {
+                        value = Some(record.zstring()?);
+                    }
+                    Attribute::String { key, value }
+                }
+                id @ (ParamAttrGrpCodes::TypeAttr | ParamAttrGrpCodes::TypeAttrTypeId) => {
+                    // Type attribute (e.g., ByVal)
+                    let kind = AttrKind::try_from(record.u8()?).unwrap();
+                    let type_id = if matches!(id, ParamAttrGrpCodes::TypeAttrTypeId) {
+                        Some(record.u64()?)
+                    } else {
+                        None
+                    };
+                    Attribute::Type { kind, type_id }
+                }
+                // 7
+                ParamAttrGrpCodes::ConstantRange => {
+                    // Constant range attribute
+                    let kind = AttrKind::try_from(record.u8()?).unwrap();
+                    let bit_width = record.u32()?;
+                    let lower = record.i64()?;
+                    let upper = record.i64()?;
+                    Attribute::ConstantRange {
+                        bit_width,
+                        kind,
+                        range: lower..upper,
+                    }
+                }
+                // 8
+                ParamAttrGrpCodes::ConstantRangeList => {
+                    // Constant range list attribute
+                    let kind = AttrKind::try_from(record.u8()?).unwrap();
+                    let num_ranges = record.u64()?;
+                    let bit_width = record.u32()?;
+                    let mut ranges = Vec::new();
+                    for _ in 0..num_ranges {
+                        let lower = record.i64()?;
+                        let upper = record.i64()?;
+                        ranges.push(lower..upper);
+                    }
+                    Attribute::ConstantRangeList {
+                        kind,
+                        bit_width,
+                        ranges,
+                    }
+                }
+            });
+        }
+
+        Ok(AttributeGroupEntry {
+            group_id,
+            index,
+            attributes,
+        })
+    }
+
+    pub fn process_vst(&mut self, vst: Vec<ValueSymtab>, mut func: Option<&mut Function>) {
+        for v in vst {
+            match v {
+                ValueSymtab::Entry(r) => {
+                    let val_id = r.value_id as usize;
+                    let name = r.name;
+                    let global_end = func
+                        .as_ref()
+                        .map(|f| f.first_local_value_list_id as usize)
+                        .unwrap_or(self.global_value_list.len());
+                    if val_id < global_end {
+                        let tmp = self.global_value_list.get_mut(val_id).expect(&name);
+                        tmp.name = Some(name);
+                    } else {
+                        let func = func.as_mut().unwrap();
+                        let local_id = val_id - global_end;
+                        let local_list = &mut func.local_value_list;
+                        let Some(tmp) = local_list.get_mut(local_id) else {
+                            continue;
+                        };
+                        tmp.name = Some(name);
+                    }
+                }
+                ValueSymtab::Bbentry(b) => {
+                    func.as_mut().unwrap().basic_blocks[b.id as usize].name = Some(b.name);
+                }
+                ValueSymtab::Fnentry(r) => {
+                    if r.name.is_some() {
+                        panic!("strtab replaced fn vst {r:?}");
+                    }
+                }
+                ValueSymtab::CombinedEntry(_) => unimplemented!(),
+            }
+        }
+    }
+
+    fn parse_type_block(&mut self, mut b: BlockIter<'_, 'input>) -> Result<(), Error> {
+        let mut name = None;
+        while let Some(mut record) = b.next_record()? {
+            let ty = match TypeCode::try_from(record.id as u8).unwrap() {
+                TypeCode::NumEntry => {
+                    let n = record.u64()?;
+                    self.types.types.reserve(n as usize);
+                    continue;
+                }
+                TypeCode::Void => Type::Void,
+                TypeCode::Half => Type::Half,
+                TypeCode::BFloat => Type::BFloat,
+                TypeCode::Float => Type::Float,
+                TypeCode::Double => Type::Double,
+                TypeCode::Label => Type::Label,
+                TypeCode::Opaque => Type::Opaque,
+                TypeCode::Integer => Type::Integer {
+                    width: record.nzu8()?.unwrap(),
+                },
+                TypeCode::Pointer => return Err(Error::Other("obsolete")),
+                TypeCode::FunctionOld => unimplemented!(),
+                TypeCode::Array => Type::Array(TypeArrayRecord {
+                    num_elements: record.u64()?,
+                    elements_type: record.u32()?,
+                }),
+                TypeCode::Vector => Type::Vector(TypeVectorRecord {
+                    num_elements: record.u64()?,
+                    elements_type: record.u32()?,
+                }),
+                TypeCode::X86Fp80 => Type::X86Fp80,
+                TypeCode::Fp128 => Type::Fp128,
+                TypeCode::PpcFp128 => Type::PpcFp128,
+                TypeCode::Metadata => Type::Metadata,
+                TypeCode::X86Mmx => Type::X86Mmx,
+                TypeCode::StructAnon => Type::Struct(TypeStructRecord {
+                    is_packed: record.next().unwrap().unwrap() != 0,
+                    element_types: record
+                        .array()?
+                        .into_iter()
+                        .map(|t| t as u32)
+                        .collect::<Vec<_>>(),
+                }),
+                TypeCode::StructName => {
+                    name = Some(record.string()?.try_into().unwrap());
+                    continue;
+                }
+                TypeCode::StructNamed => Type::Struct(TypeStructRecord {
+                    name: name.take(),
+                    is_packed: record.next().unwrap().unwrap() != 0,
+                    element_types: record
+                        .array()?
+                        .into_iter()
+                        .map(|t| t as u32)
+                        .collect::<Vec<_>>(),
+                }),
+                TypeCode::Function => {
+                    let vararg = record.bool()?;
+                    let mut array = record
+                        .array()?
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, v)| (i, v as u32));
+                    let ret_ty = array.next().map(|(_, i)| i);
+                    Type::Function(TypeFunctionRecord {
+                        vararg,
+                        ret_ty,
+                        param_types: array.map(|(_i, t)| t).collect::<Vec<_>>(),
+                    })
+                }
+                TypeCode::X86Amx => Type::X86Amx,
+                TypeCode::TargetType => {
+                    let num_tys = record.u64()? as usize;
+                    let mut ty_params = Vec::with_capacity(num_tys);
+                    for _ in 0..num_tys {
+                        ty_params.push(record.u32()?);
+                    }
+                    Type::TargetType(TypeTargetTypeRecord {
+                        ty_params,
+                        int_params: record.collect::<Result<Vec<_>, _>>()?,
+                    })
+                }
+                TypeCode::OpaquePointer => Type::OpaquePointer(TypeOpaquePointerRecord {
+                    address_space: record.u64()?,
+                }),
+                TypeCode::Token => Type::Token,
+                c => unimplemented!("type {c:?}"),
+            };
+            self.types.types.push(ty);
+        }
+        Ok(())
+    }
+
+    pub fn parse_metadata_attachment(
+        &mut self,
+        mut block: BlockIter<'_, 'input>,
+        func: &mut Function,
+    ) -> Result<(), Error> {
+        while let Some(mut record) = block.next_record()? {
+            assert_eq!(record.id, MetadataCode::Attachment as _);
+            let num_items = record.len() / 2; // round down
+
+            // instruction if present, function otherwise
+            let dest = if record.len() % 2 != 0 {
+                let inst_index = record.u64()? as InstIndex;
+
+                func.inst_metadata_attachment
+                    .entry(inst_index)
+                    .and_modify(|f| f.reserve(num_items))
+                    .or_insert_with(|| Vec::with_capacity(num_items))
+            } else {
+                func.fn_metadata_attachment.reserve(num_items);
+                &mut func.fn_metadata_attachment
+            };
+
+            for _ in 0..num_items {
+                let md_kind: MetadataKindId = record.u32()?;
+                // these may be forward refs
+                // MDStringRef + GlobalMetadataBitPosIndex
+                let md_node: MetadataNodeId = record.u32()?;
+                dest.push((md_kind, md_node));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn parse_metadata_block(
+        &mut self,
+        mut block: BlockIter<'_, 'input>,
+        mut func: Option<&mut Function>,
+    ) -> Result<(), Error> {
+        while let Some(mut record) = block.next_record()? {
+            use llvm_bitcode::dumper::metadata::*;
+
+            let m = match MetadataCode::try_from(record.id as u8).unwrap() {
+                MetadataCode::StringOld => {
+                    MetadataRecord::String(record.string()?.try_into().unwrap())
+                }
+                MetadataCode::Value => MetadataRecord::Value(MetadataValue {
+                    type_id: record.u32()?,
+                    value_id: record.u32()?,
+                }),
+                id @ (MetadataCode::Node | MetadataCode::DistinctNode) => {
+                    // NODE: [n x md num] – non-distinct MDNode.
+                    MetadataRecord::Node(MetadataNode {
+                        distinct: matches!(id, MetadataCode::DistinctNode),
+                        operands: record.collect::<Result<Vec<_>, _>>()?,
+                    })
+                }
+                MetadataCode::Name => MetadataRecord::Name(record.string()?.try_into().unwrap()),
+                MetadataCode::Location => {
+                    // LOCATION: [distinct, line, column, scope, inlined_at?, is_implicit_code]
+                    let distinct = record.bool()?;
+                    let line = record.u32()?; // assume u32 fields
+                    let column = record.u32()?;
+                    let scope = record.u64()?;
+                    let inlined_at = {
+                        let v = record.u64()?;
+                        if v == 0 { None } else { Some(v) }
+                    };
+                    let implicit_code = record.bool()?;
+                    MetadataRecord::DILocation(DILocation {
+                        distinct,
+                        line,
+                        column,
+                        scope,
+                        inlined_at,
+                        implicit_code,
+                    })
+                }
+                MetadataCode::NamedNode => MetadataRecord::NamedNode(MetadataNamedNode {
+                    mdnodes: record.collect::<Result<Vec<_>, _>>()?,
+                }),
+                MetadataCode::Attachment => unreachable!("is in a separate block"),
+                MetadataCode::GenericDebug => MetadataRecord::DIGenericNode(DIGenericNode {
+                    distinct: record.bool()?,
+                    tag: record.u32()?,
+                    version: record.u32()?,
+                    operands: record.array()?,
+                }),
+                MetadataCode::Subrange => MetadataRecord::DISubrange(DISubrange {
+                    distinct: (record.u64()? & 1) != 0,
+                    count: record.next()?,
+                    lower_bound: record.next()?,
+                    upper_bound: record.next()?,
+                    stride: record.next()?,
+                }),
+                MetadataCode::Enumerator => {
+                    // ENUMERATOR: [flags, bit_width, raw_name, wide_value...]
+                    let composite = record.u64()?;
+                    MetadataRecord::DIEnumerator(DIEnumerator {
+                        distinct: (composite & 1) != 0,
+                        is_unsigned: (composite & 2) != 0,
+                        is_big_int: (composite & 4) != 0,
+                        bit_width: record.u32()?,
+                        raw_name: record.next()?,
+                        value: record.array()?.into_iter().map(|v| v as i64).collect(),
+                    })
+                }
+                MetadataCode::BasicType => MetadataRecord::DIBasicType(DIBasicType {
+                    distinct: record.bool()?,
+                    tag: record.u32()?,
+                    raw_name: record.next()?,
+                    size_in_bits: record.u64()?,
+                    align_in_bits: record.u64()?,
+                    encoding: record.u64()?,
+                    flags: record.u64()?,
+                }),
+                MetadataCode::File => MetadataRecord::DIFile(DIFile {
+                    distinct: record.bool()?,
+                    raw_filename: record.next()?,
+                    raw_directory: record.next()?,
+                    checksum_kind: record.nzu64()?,
+                    raw_checksum: record.next()?,
+                    raw_source: record.next()?,
+                }),
+                MetadataCode::DerivedType => MetadataRecord::DIDerivedType(DIDerivedType {
+                    distinct: record.bool()?,
+                    tag: record.u32()?,
+                    raw_name: record.next()?,
+                    file: record.next()?,
+                    line: record.u32()?,
+                    scope: record.next()?,
+                    base_type: record.next()?,
+                    size_in_bits: record.u64()?,
+                    align_in_bits: record.u64()?,
+                    offset_in_bits: record.u64()?,
+                    flags: record.u64()?,
+                    extra_data: record.next()?,
+                    dwarf_address_space: record.next()?,
+                    annotations: record.next()?,
+                    ptr_auth_data: record.u64()?,
+                }),
+                MetadataCode::CompositeType => MetadataRecord::DICompositeType(DICompositeType {
+                    distinct: (record.u8()? & 1) != 0,
+                    tag: record.u32()?,
+                    raw_name: record.next()?,
+                    file: record.next()?,
+                    line: record.u32()?,
+                    scope: record.next()?,
+                    base_type: record.next()?,
+                    size_in_bits: record.u64()?,
+                    align_in_bits: record.u64()?,
+                    offset_in_bits: record.u64()?,
+                    flags: record.u64()?,
+                    elements: record.next()?,
+                    runtime_lang: record.u64()?,
+                    vtable_holder: record.next()?,
+                    template_params: record.next()?,
+                    raw_identifier: record.next()?,
+                    discriminator: record.next()?,
+                    raw_data_location: record.next()?,
+                    raw_associated: record.next()?,
+                    raw_allocated: record.next()?,
+                    raw_rank: record.next()?,
+                    annotations: record.next()?,
+                }),
+                MetadataCode::SubroutineType => {
+                    MetadataRecord::DISubroutineType(DISubroutineType {
+                        distinct: (record.u8()? & 1) != 0,
+                        flags: record.u64()?,
+                        type_array: record.u64()?,
+                        cc: record.u64()?,
+                    })
+                }
+                MetadataCode::CompileUnit => MetadataRecord::DICompileUnit(DICompileUnit {
+                    distinct: record.bool()?,
+                    source_language: record.u32()?,
+                    file: record.next()?,
+                    raw_producer: record.next()?,
+                    is_optimized: record.bool()?,
+                    raw_flags: record.next()?,
+                    runtime_version: record.u32()?,
+                    raw_split_debug_filename: record.next()?,
+                    emission_kind: record.u32()?,
+                    enum_types: record.next()?,
+                    retained_types: record.next()?,
+                    subprograms: record.u64()?,
+                    global_variables: record.next()?,
+                    imported_entities: record.next()?,
+                    dwo_id: record.u64()?,
+                    macros: record.next()?,
+                    split_debug_inlining: record.u32()?,
+                    debug_info_for_profiling: record.u32()?,
+                    name_table_kind: record.u32()?,
+                    ranges_base_address: record.u64()?,
+                    raw_sysroot: record.next()?,
+                    raw_sdk: record.next()?,
+                }),
+                MetadataCode::Subprogram => {
+                    let composite = record.u64()?; // contains several packed flags
+                    MetadataRecord::DISubprogram(DISubprogram {
+                        distinct: (composite & 1) != 0,
+                        scope: record.next()?,
+                        raw_name: record.next()?,
+                        raw_linkage_name: record.next()?,
+                        file: record.next()?,
+                        line: record.u32()?,
+                        type_id: record.next()?,
+                        scope_line: record.u32()?,
+                        containing_type: record.next()?,
+                        sp_flags: record.u64()?,
+                        virtual_index: record.u64()?,
+                        flags: record.u64()?,
+                        raw_unit: record.next()?,
+                        template_params: record.next()?,
+                        declaration: record.next()?,
+                        retained_nodes: record.next()?,
+                        this_adjustment: record.u64()?,
+                        thrown_types: record.next()?,
+                        annotations: record.next()?,
+                        raw_target_func_name: record.next()?,
+                    })
+                }
+                MetadataCode::LexicalBlock => {
+                    // LEXICAL_BLOCK: [distinct, scope, file, line, column]
+                    MetadataRecord::DILexicalBlock(DILexicalBlock {
+                        distinct: record.bool()?,
+                        scope: record.next()?,
+                        file: record.next()?,
+                        line: record.u32()?,
+                        column: record.u32()?,
+                    })
+                }
+                MetadataCode::LexicalBlockFile => {
+                    // LEXICAL_BLOCK_FILE: [distinct, scope, file, discriminator]
+                    MetadataRecord::DILexicalBlockFile(DILexicalBlockFile {
+                        distinct: record.bool()?,
+                        scope: record.next()?,
+                        file: record.next()?,
+                        discriminator: record.u64()?,
+                    })
+                }
+                MetadataCode::Namespace => {
+                    // NAMESPACE: [composite (distinct|export_symbols), scope, raw_name]
+                    let composite = record.u64()?;
+                    MetadataRecord::DINamespace(DINamespace {
+                        distinct: (composite & 1) != 0,
+                        export_symbols: (composite & 2) != 0,
+                        scope: record.next()?,
+                        raw_name: record.next()?,
+                    })
+                }
+                MetadataCode::TemplateType => {
+                    // TEMPLATE_TYPE: [distinct, raw_name, type, is_default]
+                    MetadataRecord::DITemplateTypeParameter(DITemplateTypeParameter {
+                        distinct: record.bool()?,
+                        raw_name: record.next()?,
+                        type_id: record.next()?,
+                        is_default: record.bool()?,
+                    })
+                }
+                MetadataCode::TemplateValue => {
+                    // TEMPLATE_VALUE: [distinct, tag, raw_name, type, is_default, raw_value]
+                    MetadataRecord::DITemplateValueParameter(DITemplateValueParameter {
+                        distinct: record.bool()?,
+                        tag: record.u32()?,
+                        raw_name: record.next()?,
+                        type_id: record.next()?,
+                        is_default: record.bool()?,
+                        raw_value: record.next()?,
+                    })
+                }
+                MetadataCode::GlobalVar => MetadataRecord::DIGlobalVariable(DIGlobalVariable {
+                    distinct: (record.u64()? & 1) != 0,
+                    scope: record.next()?,
+                    raw_name: record.next()?,
+                    raw_linkage_name: record.next()?,
+                    file: record.next()?,
+                    line: record.u32()?,
+                    type_id: record.next()?,
+                    is_local_to_unit: record.bool()?,
+                    is_definition: record.bool()?,
+                    static_data_member_declaration: record.next()?,
+                    template_params: record.next()?,
+                    align_in_bits: record.u64()?,
+                    annotations: record.next()?,
+                }),
+                MetadataCode::LocalVar => MetadataRecord::DILocalVariable(DILocalVariable {
+                    distinct: (record.u64()? & 1) != 0,
+                    scope: record.next()?,
+                    raw_name: record.next()?,
+                    file: record.next()?,
+                    line: record.u32()?,
+                    type_id: record.next()?,
+                    arg: record.u64()?,
+                    flags: record.u64()?,
+                    align_in_bits: record.u64()?,
+                    annotations: record.next()?,
+                }),
+                MetadataCode::Label => MetadataRecord::DILabel(DILabel {
+                    distinct: record.bool()?,
+                    scope: record.next()?,
+                    raw_name: record.next()?,
+                    file: record.next()?,
+                    line: record.u32()?,
+                }),
+                MetadataCode::Expression => {
+                    let composite = record.u64()?;
+                    MetadataRecord::DIExpression(DIExpression {
+                        distinct: (composite & 1) != 0,
+                        elements: record
+                            .map(|v| v.map(|v| v as i64))
+                            .collect::<Result<Vec<_>, _>>()?,
+                    })
+                }
+                MetadataCode::GlobalVarExpr => {
+                    MetadataRecord::DIGlobalVariableExpression(DIGlobalVariableExpression {
+                        distinct: record.bool()?,
+                        variable: record.u64()?,
+                        expression: record.u64()?,
+                    })
+                }
+                MetadataCode::ObjcProperty => MetadataRecord::DIObjCProperty(DIObjCProperty {
+                    distinct: record.bool()?,
+                    raw_name: record.next()?,
+                    file: record.next()?,
+                    line: record.u32()?,
+                    raw_setter_name: record.next()?,
+                    raw_getter_name: record.next()?,
+                    attributes: record.u64()?,
+                    type_id: record.next()?,
+                }),
+                MetadataCode::ImportedEntity => {
+                    MetadataRecord::DIImportedEntity(DIImportedEntity {
+                        distinct: record.bool()?,
+                        tag: record.u32()?,
+                        scope: record.next()?,
+                        entity: record.next()?,
+                        line: record.u32()?,
+                        raw_name: record.next()?,
+                        raw_file: record.next()?,
+                        elements: record.next()?,
+                    })
+                }
+                MetadataCode::Module => MetadataRecord::DIModule(DIModule {
+                    distinct: record.bool()?,
+                    operands: record.array()?,
+                    line_no: record.u32()?,
+                    is_decl: record.bool()?,
+                }),
+                MetadataCode::Macro => MetadataRecord::DIMacro(DIMacro {
+                    distinct: record.bool()?,
+                    macinfo_type: record.u32()?,
+                    line: record.u32()?,
+                    raw_name: record.next()?,
+                    raw_value: record.next()?,
+                }),
+                MetadataCode::MacroFile => MetadataRecord::DIMacroFile(DIMacroFile {
+                    distinct: record.bool()?,
+                    macinfo_type: record.u32()?,
+                    line: record.u32()?,
+                    file: record.next()?,
+                    elements: record.next()?,
+                }),
+                MetadataCode::ArgList => MetadataRecord::DIArgList(DIArgList {
+                    args: record.array()?,
+                }),
+                MetadataCode::AssignId => MetadataRecord::DIAssignID(DIAssignID {
+                    distinct: record.bool()?,
+                }),
+                MetadataCode::Strings => {
+                    let count = record.u64()? as usize;
+                    let start_offset = record.u64()?;
+                    let blob = record.blob()?;
+                    let (offsets, strings) = blob.split_at_checked(start_offset as usize).unwrap();
+
+                    let mut next_offset = 0;
+                    let mut c = Cursor::new(offsets);
+                    let ranges = (0..count)
+                        .map(|_| {
+                            let len = c.read_vbr(6).unwrap() as usize;
+                            let start = next_offset;
+                            next_offset += len;
+                            start..next_offset
+                        })
+                        .collect();
+
+                    MetadataRecord::Strings(MetadataStringsRecord {
+                        strings: strings.to_vec(),
+                        ranges,
+                    })
+                }
+                MetadataCode::IndexOffset | MetadataCode::Index => {
+                    // we have no use for offsets
+                    return Ok(());
+                }
+                MetadataCode::GlobalDeclAttachment => {
+                    // Implementation for METADATA_GLOBAL_DECL_ATTACHMENT
+                    // Structure: [valueid, n x [id, mdnode]]
+                    let value_id = record.u32()?;
+                    let mut attachments = Vec::new();
+                    while let Some(id) = record.next()? {
+                        let mdnode = record.u64()?;
+                        attachments.push((id, mdnode));
+                    }
+                    MetadataRecord::GlobalDeclAttachment(MetadataAttachment {
+                        value_id,
+                        attachments,
+                    })
+                }
+                id => {
+                    unimplemented!("metadata {id:?}")
+                }
+            };
+            if let Some(f) = func.as_mut() {
+                f.metadata.push(m);
+            } else {
+                self.metadata.push(m);
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -144,7 +144,7 @@ impl<'cursor, 'input> RecordIter<'cursor, 'input> {
         })
     }
 
-    fn payload(&mut self) -> Result<Option<Payload>, Error> {
+    pub fn payload(&mut self) -> Result<Option<Payload>, Error> {
         match &mut self.ops {
             Ops::Abbrev { state, abbrev } => {
                 if *state > abbrev.fields.len() {
@@ -382,6 +382,18 @@ impl<'cursor, 'input> RecordIter<'cursor, 'input> {
             s.push(b.get() as char);
         }
         Ok(s)
+    }
+
+    /// Internal ID of this record's abbreviation, if any.
+    ///
+    /// This is intended only for debugging and data dumps.
+    /// This isn't a stable identifier, and may be block-specific.
+    #[must_use]
+    pub fn debug_abbrev_id(&self) -> Option<u32> {
+        match &self.ops {
+            Ops::Abbrev { abbrev, .. } => Some(abbrev.id),
+            Ops::Full(_) => None,
+        }
     }
 }
 

--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -1,7 +1,9 @@
 use crate::bits::Cursor;
 use crate::bitstream::{Abbreviation, Operand};
 use crate::bitstream::{PayloadOperand, ScalarOperand};
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::fmt;
 use std::num::NonZero;
 use std::ops::Range;
 use std::sync::Arc;
@@ -65,7 +67,7 @@ impl Record {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum Ops {
     Abbrev {
         /// If under `abbrev.fields.len()`, then it's the next op to read
@@ -81,7 +83,6 @@ enum Ops {
 /// Data records consist of a record code and a number of (up to) 64-bit integer values
 ///
 /// The interpretation of the code and values is application specific and may vary between different block types.
-#[derive(Debug)]
 pub struct RecordIter<'cursor, 'input> {
     /// Record code
     pub id: u64,
@@ -388,6 +389,18 @@ impl<'cursor, 'input> RecordIter<'cursor, 'input> {
         }
         Ok(s)
     }
+
+    /// For debug printing
+    fn from_cloned_cursor<'new_cursor>(
+        &self,
+        cursor: &'new_cursor mut Cursor<'input>,
+    ) -> RecordIter<'new_cursor, 'input> {
+        RecordIter {
+            id: self.id,
+            ops: self.ops.clone(),
+            cursor,
+        }
+    }
 }
 
 impl Iterator for RecordIter<'_, '_> {
@@ -405,6 +418,44 @@ impl Drop for RecordIter<'_, '_> {
             if abbrev.payload.is_some() {
                 let _ = self.payload();
             }
+        }
+    }
+}
+
+struct RecordIterDebugFields<'c, 'i>(RefCell<RecordIter<'c, 'i>>);
+struct RecordIterDebugResult<T, E>(Result<T, E>);
+
+impl fmt::Debug for RecordIter<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut c = self.cursor.clone();
+        let fields = RecordIterDebugFields(RefCell::new(self.from_cloned_cursor(&mut c)));
+
+        f.debug_struct("RecordIter")
+            .field("id", &self.id)
+            .field("fields", &fields)
+            .field("ops", &self.ops)
+            .field("cursor", &self.cursor)
+            .finish()
+    }
+}
+
+impl fmt::Debug for RecordIterDebugFields<'_, '_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut iter = self.0.borrow_mut();
+        let mut d = f.debug_list();
+        d.entries(iter.by_ref().map(RecordIterDebugResult));
+        if let Some(p) = iter.payload().transpose() {
+            d.entries([RecordIterDebugResult(p)]);
+        }
+        d.finish()
+    }
+}
+
+impl<T: fmt::Debug, E: fmt::Debug> fmt::Debug for RecordIterDebugResult<T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0 {
+            Ok(t) => t.fmt(f),
+            Err(e) => e.fmt(f),
         }
     }
 }

--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -17,7 +17,7 @@ const LLVM_BITCODE_WRAPPER_MAGIC: u32 = 0x0B17C0DE;
 pub struct Bitcode {
     pub signature: Signature,
     pub elements: Vec<BitcodeElement>,
-    pub block_info: HashMap<u64, BlockInfo>,
+    pub block_info: HashMap<u32, BlockInfo>,
 }
 
 /// Blocks in a bitstream denote nested regions of the stream,
@@ -29,7 +29,7 @@ pub struct Bitcode {
 #[derive(Debug, Clone)]
 pub struct Block {
     /// Block ID
-    pub id: u64,
+    pub id: u32,
     /// Block elements
     pub elements: Vec<BitcodeElement>,
 }

--- a/src/bitcode.rs
+++ b/src/bitcode.rs
@@ -231,6 +231,11 @@ impl<'cursor, 'input> RecordIter<'cursor, 'input> {
         self.u64()?.try_into().map_err(|_| Error::ValueOverflow)
     }
 
+    pub fn try_from<U: TryFrom<u64>, T: TryFrom<U>>(&mut self) -> Result<T, Error> {
+        T::try_from(self.u64()?.try_into().map_err(|_| Error::ValueOverflow)?)
+            .map_err(|_| Error::ValueOverflow)
+    }
+
     pub fn nzu8(&mut self) -> Result<Option<NonZero<u8>>, Error> {
         self.u8().map(NonZero::new)
     }

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -158,6 +158,12 @@ impl<'input> Cursor<'input> {
         self.offset = 0;
         Ok(())
     }
+
+    /// Maximum number of bits that can be read
+    #[must_use]
+    pub fn unconsumed_bit_len(&self) -> usize {
+        (self.buffer.len() << 3) - self.offset
+    }
 }
 
 #[test]

--- a/src/bits.rs
+++ b/src/bits.rs
@@ -25,20 +25,6 @@ pub struct Cursor<'input> {
     offset: usize,
 }
 
-impl fmt::Debug for Cursor<'_> {
-    /// Debug-print only the accessible part of the internal buffer
-    #[cold]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let byte_offset = self.offset / 8;
-        let bit_offset = self.offset % 8;
-        let buffer = self.buffer.get(byte_offset..).unwrap_or_default();
-        f.debug_struct("Cursor")
-            .field("buffer", &buffer)
-            .field("offset", &bit_offset)
-            .finish()
-    }
-}
-
 impl<'input> Cursor<'input> {
     #[must_use]
     pub fn new(buffer: &'input [u8]) -> Self {
@@ -161,6 +147,37 @@ impl<'input> Cursor<'input> {
             .ok_or(Error::BufferOverflow)?;
         self.offset = 0;
         Ok(())
+    }
+}
+
+struct CursorDebugBytes<'a>(&'a [u8]);
+
+impl fmt::Debug for CursorDebugBytes<'_> {
+    #[cold]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[0x")?;
+        for &b in self.0.iter().take(200) {
+            write!(f, "{b:02x}")?;
+        }
+        if self.0.len() > 200 {
+            f.write_str("...")?;
+        }
+        write!(f, "; {}]", self.0.len())
+    }
+}
+
+impl fmt::Debug for Cursor<'_> {
+    /// Debug-print only the accessible part of the internal buffer
+    #[cold]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let byte_offset = self.offset / 8;
+        let bit_offset = self.offset % 8;
+        let buffer = CursorDebugBytes(self.buffer.get(byte_offset..).unwrap_or_default());
+        f.debug_struct("Cursor")
+            .field("offset", &bit_offset)
+            .field("buffer", &buffer)
+            .field("nextvbr6", &self.peek(6).ok())
+            .finish()
     }
 }
 

--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -105,7 +105,7 @@ pub enum BlockInfoCode {
 ///
 /// Bitstream reserves 4 special abbreviation IDs for its own bookkeeping.
 #[derive(Debug, Clone, Copy, TryFromPrimitive)]
-#[repr(u64)]
+#[repr(u32)]
 pub enum BuiltinAbbreviationId {
     /// Marks the end of the current block.
     EndBlock = 0,

--- a/src/bitstream.rs
+++ b/src/bitstream.rs
@@ -8,6 +8,7 @@ pub struct Abbreviation {
     /// All operands except the last that may be an array/string/blob
     pub fields: Vec<ScalarOperand>,
     pub payload: Option<PayloadOperand>,
+    pub id: u32,
 }
 
 /// Abbreviation operand

--- a/src/read.rs
+++ b/src/read.rs
@@ -185,7 +185,12 @@ impl BitStreamReader {
                 op => return Err(Error::UnexpectedOperand(Some(op))),
             }
         }
-        let abbrev = Arc::new(Abbreviation { fields, payload });
+        let id = abbrevs.len() as u32;
+        let abbrev = Arc::new(Abbreviation {
+            id,
+            fields,
+            payload,
+        });
         abbrevs.push(abbrev);
         Ok(())
     }
@@ -346,6 +351,25 @@ impl<'global_state, 'input> BlockIter<'global_state, 'input> {
                 abbrev,
             )?)))
         }
+    }
+
+    /// Bit width of abbreviation IDs in this block.
+    ///
+    /// This is an implementation detail,
+    /// intended only for debugging or data dumps.
+    #[must_use]
+    pub fn debug_abbrev_width(&self) -> u8 {
+        self.abbrev_width
+    }
+
+    /// Valid only before any record or subblock has been read. This is the block size in bytes.
+    ///
+    /// This is an implementation detail,
+    /// intended only for debugging or data dumps.
+    #[must_use]
+    pub fn debug_data_len(&self) -> Option<usize> {
+        let bits = self.cursor.unconsumed_bit_len();
+        (bits & 31 != 0).then_some(bits >> 3)
     }
 
     fn new(

--- a/src/schema/blocks.rs
+++ b/src/schema/blocks.rs
@@ -1,0 +1,1292 @@
+use num_enum::TryFromPrimitive;
+
+/// Enumeration of block identifiers in LLVM bitcode format.
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum BlockId {
+    /// `MODULE` block identifier
+    Module = 8,
+
+    /// `PARAMATTR` block identifier
+    ParamAttr,
+
+    /// `PARAMATTR_GROUP` block identifier
+    ParamAttrGroup,
+
+    /// `CONSTANTS_BLOCK_ID = 11`
+    Constants,
+
+    /// `FUNCTION_BLOCK_ID = 12`
+    Function,
+
+    /// Obsolete.
+    ///
+    /// Block intended to contain information on the bitcode versioning. Can be
+    /// used to provide better error messages when we fail to parse a bitcode file.
+    Identification,
+
+    /// `VALUE_SYMTAB_BLOCK_ID`
+    ValueSymtab,
+
+    /// `METADATA_BLOCK_ID`
+    Metadata,
+
+    /// `METADATA_ATTACHMENT_ID`
+    MetadataAttachment,
+
+    /// `TYPE_BLOCK_ID_NEW = 17`
+    Type = 17,
+
+    /// `USELIST_BLOCK_ID`
+    Uselist,
+
+    /// `MODULE_STRTAB_BLOCK_ID`
+    ModuleStrtab,
+
+    /// Obsolete
+    /// `GLOBALVAL_SUMMARY_BLOCK_ID`
+    GlobalvalSummary,
+
+    /// `OPERAND_BUNDLE_TAGS_BLOCK_ID`
+    OperandBundleTags,
+
+    /// `METADATA_KIND_BLOCK_ID`
+    MetadataKind,
+
+    /// `STRTAB_BLOCK_ID`
+    Strtab,
+
+    /// `FULL_LTO_GLOBALVAL_SUMMARY_BLOCK_ID`
+    FullLtoGlobalvalSummary,
+
+    /// `SYMTAB_BLOCK_ID`
+    Symtab,
+
+    /// `SYNC_SCOPE_NAMES_BLOCK_ID`
+    SyncScopeNames,
+}
+
+/// OperandBundle tag codes
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum OperandBundleTagCode {
+    /// `TAG`
+    ///
+    /// [strchr x N]
+    Tag = 1,
+}
+
+/// Sync scope name codes
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum SyncScopeNameCode {
+    /// `SYNC_SCOPE_NAME`
+    Name = 1,
+}
+
+/// STRTAB block codes
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum StrtabCode {
+    /// `STRTAB_BLOB`
+    Blob = 1,
+}
+
+/// SYMTAB block codes
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum SymtabCode {
+    /// `SYMTAB_BLOB`
+    Blob = 1,
+}
+
+/// `MODULE` blocks have a number of optional fields and subblocks.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum ModuleCode {
+    /// `VERSION`
+    ///
+    /// [version#]
+    Version = 1,
+
+    /// `TRIPLE`
+    ///
+    /// [strchr x N]
+    Triple = 2,
+
+    /// `DATALAYOUT`
+    ///
+    /// [strchr x N]
+    Datalayout = 3,
+
+    /// `ASM`
+    ///
+    /// [strchr x N]
+    Asm = 4,
+
+    /// `SECTIONNAME`
+    ///
+    /// [strchr x N]
+    SectionName = 5,
+
+    /// Obsolete.
+    ///
+    /// `DEPLIB`
+    ///
+    /// [strchr x N]
+    Deplib = 6,
+
+    /// `GLOBALVAR`
+    ///
+    /// [pointer type, isconst, initid, linkage, alignment, section, visibility, threadlocal]
+    GlobalVar = 7,
+
+    /// `FUNCTION`
+    ///
+    /// [type, callingconv, isproto, linkage, paramattrs, alignment, section, visibility, gc, unnamed_addr]
+    Function = 8,
+
+    /// Obsolete alias record; replaced by `MODULE_CODE_ALIAS`
+    ///
+    /// `ALIAS`
+    ///
+    /// [alias type, aliasee val#, linkage, visibility]
+    AliasOld = 9,
+
+    /// `GCNAME`
+    ///
+    /// [strchr x N]
+    GCName = 11,
+
+    /// `COMDAT`
+    ///
+    /// [selection_kind, name]
+    Comdat = 12,
+
+    /// `VSTOFFSET`
+    ///
+    /// [offset]
+    VstOffset = 13,
+
+    /// `ALIAS`
+    ///
+    /// [alias value type, addrspace, aliasee val#, linkage, visibility]
+    Alias = 14,
+
+    /// Defined in the MODULE block but never emitted (Obsolete)
+    MetadataValuesUnused = 15,
+
+    /// `SOURCE_FILENAME`
+    ///
+    /// [namechar x N]
+    SourceFilename = 16,
+
+    /// `HASH`
+    ///
+    /// [5*i32]
+    Hash = 17,
+
+    /// `IFUNC`
+    ///
+    /// [ifunc value type, addrspace, resolver val#, linkage, visibility]
+    Ifunc = 18,
+}
+
+/// The global value summary block contains codes for defining the global value summary information.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum GlobalValueSummaryCode {
+    /// `PERMODULE`
+    ///
+    /// [valueid, flags, instcount, numrefs, numrefs x valueid, n x (valueid)]
+    PerModule = 1,
+
+    /// `PERMODULE_PROFILE`
+    ///
+    /// [valueid, flags, instcount, numrefs, numrefs x valueid, n x (valueid, hotness+tailcall)]
+    PerModuleProfile = 2,
+
+    /// `PERMODULE_GLOBALVAR_INIT_REFS`
+    ///
+    /// [valueid, flags, n x valueid]
+    PerModuleGlobalvarInitRefs = 3,
+
+    /// `COMBINED`
+    ///
+    /// [valueid, modid, flags, instcount, numrefs, numrefs x valueid, n x (valueid)]
+    Combined = 4,
+
+    /// `COMBINED_PROFILE`
+    ///
+    /// [valueid, modid, flags, instcount, numrefs, numrefs x valueid, n x (valueid, hotness+tailcall)]
+    CombinedProfile = 5,
+
+    /// `COMBINED_GLOBALVAR_INIT_REFS`
+    ///
+    /// [valueid, modid, flags, n x valueid]
+    CombinedGlobalvarInitRefs = 6,
+
+    /// `ALIAS`
+    ///
+    /// [valueid, flags, valueid]
+    Alias = 7,
+
+    /// `COMBINED_ALIAS`
+    ///
+    /// [valueid, modid, flags, valueid]
+    CombinedAlias = 8,
+
+    /// `COMBINED_ORIGINAL_NAME`
+    ///
+    /// [original_name_hash]
+    CombinedOriginalName = 9,
+
+    /// `VERSION` of the summary, bumped when adding flags for instance.
+    Version = 10,
+
+    /// The list of `llvm.type.test` type identifiers used by the following function that are used
+    /// other than by an `llvm.assume`.
+    ///
+    /// [n x typeid]
+    TypeTests = 11,
+
+    /// The list of virtual calls made by this function using `llvm.assume(llvm.type.test)` intrinsics
+    /// that do not have all constant integer arguments.
+    ///
+    /// [n x (typeid, offset)]
+    TypeTestAssumeVCalls = 12,
+
+    /// The list of virtual calls made by this function using `llvm.type.checked.load` intrinsics
+    /// that do not have all constant integer arguments.
+    ///
+    /// [n x (typeid, offset)]
+    TypeCheckedLoadVCalls = 13,
+
+    /// Identifies a virtual call made by this function using an `llvm.assume(llvm.type.test)`
+    /// intrinsic with all constant integer arguments.
+    ///
+    /// [typeid, offset, n x arg]
+    TypeTestAssumeConstVCall = 14,
+
+    /// Identifies a virtual call made by this function using an `llvm.type.checked.load` intrinsic
+    /// with all constant integer arguments.
+    ///
+    /// [typeid, offset, n x arg]
+    TypeCheckedLoadConstVCall = 15,
+
+    /// Assigns a GUID to a value ID. This normally appears only in combined summaries,
+
+    /// but it can also appear in per-module summaries for PGO data.
+    ///
+    /// [valueid, guid]
+    ValueGuid = 16,
+
+    /// The list of local functions with CFI jump tables. Function names are strings in `strtab`.
+    ///
+    /// [n * name]
+    CfiFunctionDefs = 17,
+
+    /// The list of external functions with CFI jump tables. Function names are strings in `strtab`.
+    ///
+    /// [n * name]
+    CfiFunctionDecls = 18,
+
+    /// Per-module summary that also adds relative block frequency to callee info.
+    ///
+    /// `PERMODULE_RELBF`
+    ///
+    /// [valueid, flags, instcount, numrefs, numrefs x valueid, n x (valueid, relblockfreq+tailcall)]
+    PerModuleRelBf = 19,
+
+    /// Index-wide flags
+    Flags = 20,
+
+    /// Maps type identifier to summary information for that type identifier. Produced by the thin link
+    /// (only lives in combined index).
+    ///
+    /// `TYPE_ID`
+    ///
+    /// [typeid, kind, bitwidth, align, size, bitmask, inlinebits, n x (typeid, kind, name, numrba, numrba x (numarg, numarg x arg, kind, info, byte, bit)]
+    TypeId = 21,
+
+    /// Maps type identifier to summary information for that type identifier computed from type metadata:
+    /// the valueid of each vtable definition decorated with a type metadata for that identifier,
+
+    /// and the offset from the corresponding type metadata.
+    /// Exists in the per-module summary to provide information to thin link for index-based whole
+    /// program devirtualization.
+    ///
+    /// `TYPE_ID_METADATA`
+    ///
+    /// [typeid, n x (valueid, offset)]
+    TypeIdMetadata = 22,
+
+    /// Summarizes vtable definition for use in index-based whole program devirtualization during the thin link.
+    ///
+    /// `PERMODULE_VTABLE_GLOBALVAR_INIT_REFS`
+    ///
+    /// [valueid, flags, varflags, numrefs, numrefs x valueid, n x (valueid, offset)]
+    PerModuleVtableGlobalvarInitRefs = 23,
+
+    /// The total number of basic blocks in the module.
+    BlockCount = 24,
+
+    /// Range information for accessed offsets for every argument.
+    ///
+    /// [n x (paramno, range, numcalls, numcalls x (callee_guid, paramno, range))]
+    ParamAccess = 25,
+
+    /// Summary of per-module memprof callsite metadata.
+    ///
+    /// [valueid, n x stackidindex]
+    PerModuleCallsiteInfo = 26,
+
+    /// Summary of per-module allocation memprof metadata.
+    ///
+    /// [nummib, nummib x (alloc type, context radix tree index), [nummib x (numcontext x total size)]?]
+    PerModuleAllocInfo = 27,
+
+    /// Summary of combined index memprof callsite metadata.
+    ///
+    /// [valueid, context radix tree index, numver, numver x version]
+    CombinedCallsiteInfo = 28,
+
+    /// Summary of combined index allocation memprof metadata.
+    ///
+    /// [nummib, numver, nummib x (alloc type, numstackids, numstackids x stackidindex), numver x version]
+    CombinedAllocInfo = 29,
+
+    /// List of all stack ids referenced by index in the callsite and alloc infos.
+    ///
+    /// [n x stack id]
+    StackIds = 30,
+
+    /// List of all full stack id pairs corresponding to the total sizes recorded at the end of the alloc info
+    /// when reporting of hinted bytes is enabled.
+    ///
+    /// [nummib x (numcontext x full stack id)]
+    AllocContextIds = 31,
+
+    /// Linearized radix tree of allocation contexts.
+    ///
+    /// [n x entry]
+    ContextRadixTreeArray = 32,
+}
+
+/// `METADATA` block codes
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum MetadataCode {
+    /// `MDSTRING`
+    ///
+    /// [values]
+    StringOld = 1,
+
+    /// `VALUE`
+    ///
+    /// [type num, value num]
+    Value = 2,
+
+    /// `NODE`
+    ///
+    /// [n x md num]
+    Node = 3,
+
+    /// `STRING`
+    ///
+    /// [values]
+    Name = 4,
+
+    /// `DISTINCT_NODE`
+    ///
+    /// [n x md num]
+    DistinctNode = 5,
+
+    /// `KIND`
+    ///
+    /// [n x [id, name]]
+    Kind = 6,
+
+    /// `LOCATION`
+    ///
+    /// [distinct, line, col, scope, inlined-at?]
+    Location = 7,
+
+    /// `OLD_NODE`
+    ///
+    /// [n x (type num, value num)]
+    OldNode = 8,
+
+    /// `OLD_FN_NODE`
+    ///
+    /// [n x (type num, value num)]
+    OldFnNode = 9,
+
+    /// `NAMED_NODE`
+    ///
+    /// [n x mdnodes]
+    NamedNode = 10,
+
+    /// `ATTACHMENT`
+    ///
+    /// [m x [value, [n x [id, mdnode]]]
+    Attachment = 11,
+
+    /// `GENERIC_DEBUG`
+    ///
+    /// [distinct, tag, vers, header, n x md num]
+    GenericDebug = 12,
+
+    /// `SUBRANGE`
+    ///
+    /// [distinct, count, lo]
+    Subrange = 13,
+
+    /// `ENUMERATOR`
+    ///
+    /// [isUnsigned|distinct, value, name]
+    Enumerator = 14,
+
+    /// `BASIC_TYPE`
+    ///
+    /// [distinct, tag, name, size, align, enc]
+    BasicType = 15,
+
+    /// `FILE`
+    ///
+    /// [distinct, filename, directory, checksumkind, checksum]
+    File = 16,
+
+    /// `DERIVED_TYPE`
+    ///
+    /// [distinct, ...]
+    DerivedType = 17,
+
+    /// `COMPOSITE_TYPE`
+    ///
+    /// [distinct, ...]
+    CompositeType = 18,
+
+    /// `SUBROUTINE_TYPE`
+    ///
+    /// [distinct, flags, types, cc]
+    SubroutineType = 19,
+
+    /// `COMPILE_UNIT`
+    ///
+    /// [distinct, ...]
+    CompileUnit = 20,
+
+    /// `SUBPROGRAM`
+    ///
+    /// [distinct, ...]
+    Subprogram = 21,
+
+    /// `LEXICAL_BLOCK`
+    ///
+    /// [distinct, scope, file, line, column]
+    LexicalBlock = 22,
+
+    /// `LEXICAL_BLOCK_FILE`
+    ///
+    /// [distinct, scope, file, discriminator]
+    LexicalBlockFile = 23,
+
+    /// `NAMESPACE`
+    ///
+    /// [distinct, scope, file, name, line, exportSymbols]
+    Namespace = 24,
+
+    /// `TEMPLATE_TYPE`
+    ///
+    /// [distinct, scope, name, type, ...]
+    TemplateType = 25,
+
+    /// `TEMPLATE_VALUE`
+    ///
+    /// [distinct, scope, name, type, value, ...]
+    TemplateValue = 26,
+
+    /// `GLOBAL_VAR`
+    ///
+    /// [distinct, ...]
+    GlobalVar = 27,
+
+    /// `LOCAL_VAR`
+    ///
+    /// [distinct, ...]
+    LocalVar = 28,
+
+    /// `EXPRESSION`
+    ///
+    /// [distinct, n x element]
+    Expression = 29,
+
+    /// `OBJC_PROPERTY`
+    ///
+    /// [distinct, name, file, line, ...]
+    ObjcProperty = 30,
+
+    /// `IMPORTED_ENTITY`
+    ///
+    /// [distinct, tag, scope, entity, line, name]
+    ImportedEntity = 31,
+
+    /// `MODULE`
+    ///
+    /// [distinct, scope, name, ...]
+    Module = 32,
+
+    /// `MACRO`
+    ///
+    /// [distinct, macinfo, line, name, value]
+    Macro = 33,
+
+    /// `MACRO_FILE`
+    ///
+    /// [distinct, macinfo, line, file, ...]
+    MacroFile = 34,
+
+    /// `STRINGS`
+    ///
+    /// [count, offset] blob([lengths][chars])
+    Strings = 35,
+
+    /// `GLOBAL_DECL_ATTACHMENT`
+    ///
+    /// [valueid, n x [id, mdnode]]
+    GlobalDeclAttachment = 36,
+
+    /// `GLOBAL_VAR_EXPR`
+    ///
+    /// [distinct, var, expr]
+    GlobalVarExpr = 37,
+
+    /// `INDEX_OFFSET`
+    ///
+    /// [offset]
+    IndexOffset = 38,
+
+    /// `INDEX`
+    ///
+    /// [bitpos]
+    Index = 39,
+
+    /// `LABEL`
+    ///
+    /// [distinct, scope, name, file, line]
+    Label = 40,
+
+    /// `STRING_TYPE`
+    ///
+    /// [distinct, name, size, align, ..]
+    StringType = 41,
+
+    /// `COMMON_BLOCK`
+    ///
+    /// [distinct, scope, name, variable, ..]
+    CommonBlock = 44,
+
+    /// `GENERIC_SUBRANGE`
+    ///
+    /// [distinct, count, lo, up, stride]
+    GenericSubrange = 45,
+
+    /// `ARG_LIST`
+    ///
+    /// [n x [type num, value num]]
+    ArgList = 46,
+
+    /// `ASSIGN_ID`
+    ///
+    /// [distinct, ...]
+    AssignId = 47,
+}
+
+/// `USELISTBLOCK` encoded values for a value's use-list.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum UselistCode {
+    /// `DEFAULT`
+    ///
+    /// [index..., value-id]
+    Default = 1,
+
+    /// `BB`
+    ///
+    /// [index..., bb-id]
+    BB = 2,
+}
+
+/// Identification block contains a string that describes the producer details,
+/// and an epoch that defines the auto-upgrade capability.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum IdentificationCode {
+    /// `IDENTIFICATION`
+    ///
+    /// [strchr x N]
+    String = 1,
+
+    /// `EPOCH`
+    ///
+    /// [epoch#]
+    Epoch = 2,
+}
+
+/// `PARAMATTR` blocks have code for defining a parameter attribute set.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum AttributeCode {
+    /// `ENTRY`
+    ///
+    /// [paramidx0, attr0, paramidx1, attr1...]
+    EntryOld = 1,
+
+    /// `ENTRY`
+    ///
+    /// [attrgrp0, attrgrp1, ...]
+    Entry = 2,
+
+    /// `ENTRY`
+    ///
+    /// [grpid, idx, attr0, attr1, ...]
+    GrpCodeEntry = 3,
+}
+
+/// Value symbol table codes.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum ValueSymtabCode {
+    /// `VST_ENTRY`
+    ///
+    /// [valueid, namechar x N]
+    Entry = 1,
+
+    /// `VST_BBENTRY`
+    ///
+    /// [bbid, namechar x N]
+    BbEntry = 2,
+
+    /// `VST_FNENTRY`
+    ///
+    /// Unused when strtab is present
+    ///
+    /// [valueid, offset, namechar x N]
+    FnEntry = 3,
+
+    /// Obsolete.
+    ///
+    /// `VST_COMBINED_ENTRY`
+    ///
+    /// [valueid, refguid]
+    CombinedEntry = 5,
+}
+
+/// `TYPE` blocks have codes for each type primitive they use.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum TypeCode {
+    /// `NUMENTRY`
+    ///
+    /// [numentries]
+    NumEntry = 1,
+
+    /// `VOID`
+    Void = 2,
+
+    /// `FLOAT`
+    Float = 3,
+
+    /// `DOUBLE`
+    Double = 4,
+
+    /// `LABEL`
+    Label = 5,
+
+    /// `OPAQUE`
+    Opaque = 6,
+
+    /// `INTEGER`
+    ///
+    /// [width]
+    Integer = 7,
+
+    /// Typed pointers are obsolete.
+    ///
+    /// [pointee type]
+    Pointer = 8,
+
+    /// Obsolete
+    ///
+    /// [vararg, attrid, retty, paramty x N]
+    FunctionOld = 9,
+
+    /// `HALF`
+    Half = 10,
+
+    /// `ARRAY`
+    ///
+    /// [num_elements, elements_type]
+    Array = 11,
+
+    /// `VECTOR`
+    ///
+    /// [num_elements, elements_type]
+    Vector = 12,
+
+    /// `X86 LONG DOUBLE`
+    X86Fp80 = 13,
+
+    /// `LONG DOUBLE` (112 bit mantissa)
+    Fp128 = 14,
+
+    /// `PPC LONG DOUBLE` (2 doubles)
+    PpcFp128 = 15,
+
+    /// `METADATA`
+    Metadata = 16,
+
+    /// Unused
+    ///
+    /// `X86 MMX`
+    X86Mmx = 17,
+
+    /// `STRUCT_ANON`
+    ///
+    /// [ispacked, elements_type x N]
+    StructAnon = 18,
+
+    /// `STRUCT_NAME`
+    ///
+    /// [strchr x N]
+    StructName = 19,
+
+    /// `STRUCT_NAMED`
+    ///
+    /// [ispacked, elements_type x N]
+    StructNamed = 20,
+
+    /// `FUNCTION`
+    ///
+    /// [vararg, retty, paramty x N]
+    Function = 21,
+
+    /// `TOKEN`
+    Token = 22,
+
+    /// `BRAIN FLOATING POINT`
+    BFloat = 23,
+
+    /// `X86 AMX`
+    X86Amx = 24,
+
+    /// `OPAQUE_POINTER`
+    ///
+    /// [addrspace]
+    OpaquePointer = 25,
+
+    /// `TARGET_TYPE`
+    TargetType = 26,
+}
+
+// The constants block (`CONSTANTS_BLOCK_ID` describes emission for each
+// constant and maintains an implicit current type value.
+#[derive(PartialEq, Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum ConstantsCodes {
+    /// `SETTYPE`
+    ///
+    /// [typeid]
+    Settype = 1,
+
+    /// `NULL`
+    Null = 2,
+
+    /// `UNDEF`
+    Undef = 3,
+
+    /// `INTEGER`
+    ///
+    /// [intval]
+    Integer = 4,
+
+    /// `WIDE_INTEGER`
+    ///
+    /// [n x intval]
+    WideInteger = 5,
+
+    /// `FLOAT`
+    ///
+    /// [fpval]
+    Float = 6,
+
+    /// `AGGREGATE`
+    ///
+    /// [n x value number]
+    Aggregate = 7,
+
+    /// `STRING`
+    ///
+    /// [values]
+    String = 8,
+
+    /// `CSTRING`
+    ///
+    /// [values]
+    CString = 9,
+
+    /// `CE_BINOP`
+    ///
+    /// [opcode, opval, opval]
+    BinOp = 10,
+
+    /// `CE_CAST`
+    ///
+    /// [opcode, opty, opval]
+    Cast = 11,
+
+    /// Obsolete “constant expression” GEP record; replaced by `CST_CODE_CE_GEP`
+    ///
+    /// `CE_GEP`
+    ///
+    /// [n x operands]
+    GepOld = 12,
+
+    /// Unused
+    ///
+    /// `CE_SELECT`
+    ///
+    /// [opval, opval, opval]
+    Select = 13,
+
+    /// `CE_EXTRACTELT`
+    ///
+    /// [opty, opval, opval]
+    ExtractElt = 14,
+
+    /// `CE_INSERTELT`
+    ///
+    /// [opval, opval, opval]
+    InsertElt = 15,
+
+    /// `CE_SHUFFLEVEC`
+    ///
+    /// [opval, opval, opval]
+    ShuffleVec = 16,
+
+    /// Unused.
+    ///
+    /// `CE_CMP`
+    ///
+    /// [opty, opval, opval, pred]
+    Cmp = 17,
+
+    /// Obsolete inline asm record variant
+    ///
+    /// `INLINEASM`
+    ///
+    /// [sideeffect|alignstack, asmstr, onststr]
+    InlineasmOld = 18,
+
+    /// `SHUFVEC_EX`
+    ///
+    /// [opty, opval, opval, opval]
+    ShufVecEx = 19,
+
+    /// Obsolete.
+    ///
+    /// `INBOUNDS_GEP`
+    ///
+    /// [n x operands]
+    InboundsGep = 20,
+
+    /// `BLOCKADDRESS`
+    ///
+    /// [fnty, fnval, bb#]
+    BlockAddress = 21,
+
+    /// `DATA`
+    ///
+    /// [n x elements]
+    Data = 22,
+
+    /// Obsolete inline asm encoding variant
+    ///
+    /// `INLINEASM`
+    ///
+    /// [sideeffect|alignstack|asmdialect, smstr, onststr]
+    InlineAsmOld2 = 23,
+
+    /// [opty, flags, n x operands]
+    GepWithInrangeIndexOld = 24,
+
+    /// `CST_CODE_CE_UNOP`
+    ///
+    /// [opcode, opval]
+    UnOp = 25,
+
+    /// `POISON`
+    Poison = 26,
+
+    /// `DSO_LOCAL_EQUIVALENT`
+    ///
+    /// [gvty, gv]
+    DsoLocalEquivalent = 27,
+
+    /// Obsolete variant for inline asm
+    ///
+    /// `INLINEASM`
+    ///
+    /// [sideeffect|alignstack|asmdialect|unwind, asmstr, onststr]
+    InlineAsmOld3 = 28,
+
+    /// `NO_CFI`
+    ///
+    /// [fty, f]
+    NoCfiValue = 29,
+
+    /// `INLINEASM`
+    ///
+    /// [fnty, sideeffect|alignstack|asmdialect|unwind, asmstr, onststr]
+    InlineAsm = 30,
+
+    /// CST_CODE_CE_GEP_WITH_INRANGE
+    /// [opty, flags, range, n x operands]
+    GepWithInrange = 31,
+
+    /// CST_CODE_CE_GEP
+    /// [opty, flags, n x operands]
+    Gep = 32,
+
+    /// CST_CODE_PTRAUTH
+    /// [ptr, key, disc, addrdisc]
+    PtrAuth = 33,
+}
+
+// The function body block (`FUNCTION_BLOCK_ID`) describes function bodies. It
+// can contain a constant block (`CONSTANTS_BLOCK_ID`).
+#[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum FunctionCode {
+    /// `DECLAREBLOCKS`
+    ///
+    /// [n]
+    DeclareBlocks = 1,
+
+    /// `BINOP`
+    ///
+    /// [opcode, ty, opval, opval]
+    BinOp = 2,
+
+    /// `CAST`
+    ///
+    /// [opcode, ty, opty, opval]
+    Cast = 3,
+
+    /// Old GEP instruction record; superseded by `FUNC_CODE_INST_GEP`
+    ///
+    /// `GEP`
+    ///
+    /// [n x operands]
+    GepOld = 4,
+
+    /// Unused.
+    ///
+    /// `SELECT`
+    ///
+    /// [ty, opval, opval, opval]
+    SelectOld = 5,
+
+    /// `EXTRACTELT`
+    ///
+    /// [opty, opval, opval]
+    ExtractElt = 6,
+
+    /// `INSERTELT`
+    ///
+    /// [ty, opval, opval, opval]
+    InsertElt = 7,
+
+    /// `SHUFFLEVEC`
+    ///
+    /// [ty, opval, opval, opval]
+    ShuffleVec = 8,
+
+    /// `CMP`
+    ///
+    /// [opty, opval, opval, pred]
+    Cmp = 9,
+
+    /// `RET`
+    ///
+    /// [opty, pval<both optional>]
+    Ret = 10,
+
+    /// `BR`
+    ///
+    /// [bb#, bb#, cond] or [bb#]
+    Br = 11,
+
+    /// `SWITCH`
+    ///
+    /// [opty, op0, op1, ...]
+    Switch = 12,
+
+    /// `INVOKE`
+    ///
+    /// [attr, fnty, op0, op1, ...]
+    Invoke = 13,
+
+    /// `UNREACHABLE`
+    Unreachable = 15,
+
+    /// `PHI`
+    ///
+    /// [ty, val0, b0, ...]
+    Phi = 16,
+
+    /// `ALLOCA`
+    ///
+    /// [instty, opty, op, align]
+    Alloca = 19,
+
+    /// `LOAD`
+    ///
+    /// [opty, op, align, vol]
+    Load = 20,
+
+    /// `VAARG`
+    ///
+    /// [valistty, valist, instty]
+    VaArg = 23,
+
+    // This store code encodes the pointer type, rather than the value type
+    // this is so information only available in the pointer type (e.g. address
+    // spaces) is retained.
+    /// Obsolete store record; replaced by `FUNC_CODE_INST_STORE`
+    ///
+    /// `STORE`
+    ///
+    /// [ptrty, tr, al, align, vol]
+    StoreOld = 24,
+
+    /// `EXTRACTVAL`
+    ///
+    /// [n x operands]
+    ExtractVal = 26,
+
+    /// `INSERTVAL`
+    ///
+    /// [n x operands]
+    InsertVal = 27,
+
+    /// `CMP2`
+    ///
+    /// fcmp/icmp returning Int1TY or vector of Int1Ty. Same as `CMP`, exists to
+    /// support legacy vicmp/vfcmp instructions.
+    ///
+    /// [opty, opval, opval, pred]
+    Cmp2 = 28,
+
+    /// `VSELECT`
+    ///
+    /// new select on i1 or [N x i1]
+    ///
+    /// [ty, pval, pval, redty, red]
+    Vselect = 29,
+
+    /// Obsolete inbounds GEP record; replaced by the newer `FUNC_CODE_INST_GEP`
+    ///
+    /// `INBOUNDS_GEP`
+    ///
+    /// [n x operands]
+    InboundsGepOld = 30,
+
+    /// `INDIRECTBR`
+    ///
+    /// [opty, op0, op1, ...]
+    IndirectBr = 31,
+
+    /// `DEBUG_LOC_AGAIN`
+    DebugLocAgain = 33,
+
+    /// `CALL`
+    ///
+    /// [attr, cc, fnty, fnid, args...]
+    Call = 34,
+
+    /// `DEBUG_LOC`
+    ///
+    /// [Line, ol, copeVal, IAVal]
+    DebugLoc = 35,
+
+    /// `FENCE`
+    ///
+    /// [ordering, synchscope]
+    Fence = 36,
+
+    /// Old cmpxchg record; replaced by `FUNC_CODE_INST_CMPXCHG`
+    ///
+    /// `CMPXCHG`
+    ///
+    /// [ptrty, ptr, cmp, val, vol, ordering, synchscope, failure_ordering?, weak?]
+    CmpxchgOld = 37,
+
+    /// Obsolete atomicrmw record; replaced by `FUNC_CODE_INST_ATOMICRMW`
+    ///
+    /// `ATOMICRMW`
+    ///
+    /// [ptrty, tr, al, operation, align, vol, ordering, synchscope]
+    AtomicRmwOld = 38,
+
+    /// `RESUME`
+    ///
+    /// [opval]
+    Resume = 39,
+
+    /// Obsolete landingpad record; replaced by `FUNC_CODE_INST_LANDINGPAD`
+    ///
+    /// `LANDINGPAD`
+    ///
+    /// [ty, al, al, um, d0, al0...]
+    LandingPadOld = 40,
+
+    /// `LOAD`
+    ///
+    /// [opty, op, align, vol, ordering, synchscope]
+    LoadAtomic = 41,
+
+    /// Obsolete store-atomic record; replaced by `FUNC_CODE_INST_STOREATOMIC`
+    ///
+    /// `STORE`
+    ///
+    /// [ptrty, tr, al, align, vol ordering, synchscope]
+    StoreAtomicOld = 42,
+
+    /// `GEP`
+    ///
+    /// [inbounds, n x operands]
+    Gep = 43,
+
+    /// `STORE`
+    ///
+    /// [ptrty, tr, alty, al, align, vol]
+    Store = 44,
+
+    /// `STORE`
+    ///
+    /// [ptrty, tr, al, align, vol]
+    StoreAtomic = 45,
+
+    /// `CMPXCHG`
+    ///
+    /// [ptrty, ptr, cmp, val, vol, success_ordering, synchscope, failure_ordering, weak]
+    Cmpxchg = 46,
+
+    /// `LANDINGPAD`
+    ///
+    /// [ty, al, um, d0, al0...]
+    LandingPad = 47,
+
+    /// `CLEANUPRET`
+    ///
+    /// [val] or [val, b#]
+    CleanupRet = 48,
+
+    /// `CATCHRET`
+    ///
+    /// [val, b#]
+    CatchRet = 49,
+
+    /// `CATCHPAD`
+    ///
+    /// [bb#, b#, um, rgs...]
+    CatchPad = 50,
+
+    /// `CLEANUPPAD`
+    ///
+    /// [num, rgs...]
+    CleanupPad = 51,
+
+    /// `CATCHSWITCH`
+    ///
+    /// [num, rgs...] or [num, rgs..., b]
+    CatchSwitch = 52,
+
+    /// `OPERAND_BUNDLE`
+    ///
+    /// [tag#, value...]
+    OperandBundle = 55,
+
+    /// `UNOP`
+    ///
+    /// [opcode, ty, opval]
+    UnOp = 56,
+
+    /// `CALLBR`
+    ///
+    /// [attr, cc, norm, transfs, fnty, fnid, args...]
+    CallBr = 57,
+
+    /// `FREEZE`
+    ///
+    /// [opty, opval]
+    Freeze = 58,
+
+    /// `ATOMICRMW`
+    ///
+    /// [ptrty, ptr, valty, val, operation, align, vol, ordering, synchscope]
+    AtomicRmw = 59,
+
+    /// `BLOCKADDR_USERS`
+    ///
+    /// [value...]
+    BlockaddrUsers = 60,
+
+    /// [DILocation, DILocalVariable, DIExpression, ValueAsMetadata]
+    DebugRecordValue = 61,
+
+    /// [DILocation, DILocalVariable, DIExpression, ValueAsMetadata]
+    DebugRecordDeclare = 62,
+
+    /// [DILocation, DILocalVariable, DIExpression, ValueAsMetadata, DIAssignID, DIExpression (addr), ValueAsMetadata (addr)]
+    DebugRecordAssign = 63,
+
+    /// [DILocation, DILocalVariable, DIExpression, Value]
+    DebugRecordValueSimple = 64,
+
+    /// [DILocation, DILabel]
+    DebugRecordLabel = 65,
+}
+
+/// `MODULEPATH_SYMTAB` block codes
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum ModulePathSymtabCode {
+    /// `MST_ENTRY`
+    ///
+    /// [modid, namechar x N]
+    Entry = 1,
+
+    /// `MST_HASH`
+    ///
+    /// [5*i32]
+    Hash = 2,
+}

--- a/src/schema/enums.rs
+++ b/src/schema/enums.rs
@@ -1,0 +1,387 @@
+use num_enum::TryFromPrimitive;
+
+#[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
+pub enum AttrKind {
+    // = 0 is unused
+    Alignment = 1,
+    AlwaysInline = 2,
+    ByVal = 3,
+    InlineHint = 4,
+    InReg = 5,
+    MinSize = 6,
+    Naked = 7,
+    Nest = 8,
+    NoAlias = 9,
+    NoBuiltin = 10,
+    NoCapture = 11,
+    NoDuplicate = 12,
+    NoImplicitFloat = 13,
+    NoInline = 14,
+    NonLazyBind = 15,
+    NoRedZone = 16,
+    NoReturn = 17,
+    NoUnwind = 18,
+    OptimizeForSize = 19,
+    ReadNone = 20,
+    ReadOnly = 21,
+    Returned = 22,
+    ReturnsTwice = 23,
+    SExt = 24,
+    StackAlignment = 25,
+    StackProtect = 26,
+    StackProtectReq = 27,
+    StackProtectStrong = 28,
+    StructRet = 29,
+    SanitizeAddress = 30,
+    SanitizeThread = 31,
+    SanitizeMemory = 32,
+    UwTable = 33,
+    ZExt = 34,
+    Builtin = 35,
+    Cold = 36,
+    OptimizeNone = 37,
+    InAlloca = 38,
+    NonNull = 39,
+    JumpTable = 40,
+    Dereferenceable = 41,
+    DereferenceableOrNull = 42,
+    Convergent = 43,
+    Safestack = 44,
+    /// Unused
+    ArgMemOnly = 45,
+    SwiftSelf = 46,
+    SwiftError = 47,
+    NoRecurse = 48,
+    /// Unused
+    InaccessibleMemOnly = 49,
+    /// Unused
+    InaccessiblememOrArgMemOnly = 50,
+    AllocSize = 51,
+    Writeonly = 52,
+    Speculatable = 53,
+    StrictFp = 54,
+    SanitizeHwaddress = 55,
+    NocfCheck = 56,
+    OptForFuzzing = 57,
+    Shadowcallstack = 58,
+    SpeculativeLoadHardening = 59,
+    Immarg = 60,
+    Willreturn = 61,
+    Nofree = 62,
+    Nosync = 63,
+    SanitizeMemtag = 64,
+    Preallocated = 65,
+    NoMerge = 66,
+    NullPointerIsValid = 67,
+    Noundef = 68,
+    Byref = 69,
+    Mustprogress = 70,
+    NoCallback = 71,
+    Hot = 72,
+    NoProfile = 73,
+    VscaleRange = 74,
+    SwiftAsync = 75,
+    NoSanitizeCoverage = 76,
+    Elementtype = 77,
+    DisableSanitizerInstrumentation = 78,
+    NoSanitizeBounds = 79,
+    AllocAlign = 80,
+    AllocatedPointer = 81,
+    AllocKind = 82,
+    PresplitCoroutine = 83,
+    FnretthunkExtern = 84,
+    SkipProfile = 85,
+    Memory = 86,
+    Nofpclass = 87,
+    OptimizeForDebugging = 88,
+    Writable = 89,
+    CoroOnlyDestroyWhenComplete = 90,
+    DeadOnUnwind = 91,
+    Range = 92,
+    SanitizeNumericalStability = 93,
+    Initializes = 94,
+    HybridPatchable = 95,
+}
+
+/// CastOpcodes - These are values used in the bitcode files to encode which
+/// cast a CST_CODE_CE_CAST or a XXX refers to.  The values of these enums
+/// have no fixed relation to the LLVM IR enum values.  Changing these will
+/// break compatibility with old files.
+#[derive(Debug, TryFromPrimitive)]
+#[repr(u8)]
+pub enum CastOpcode {
+    Trunc = 0,
+    ZExt = 1,
+    SExt = 2,
+    FpToUi = 3,
+    FpToSi = 4,
+    UiToFp = 5,
+    SiToFp = 6,
+    FpTrunc = 7,
+    FpExt = 8,
+    PtrToInt = 9,
+    IntToPtr = 10,
+    Bitcast = 11,
+    Addrspace = 12,
+}
+
+#[derive(Debug, TryFromPrimitive)]
+#[repr(u8)]
+pub enum Linkage {
+    External = 0,
+    Weak = 1,
+    Appending = 2,
+    Internal = 3,
+    Linkonce = 4,
+    Dllimport = 5,
+    Dllexport = 6,
+    ExternWeak = 7,
+    Common = 8,
+    Private = 9,
+    WeakOdr = 10,
+    LinkonceOdr = 11,
+    AvailableExternally = 12,
+    Deprecated1 = 13,
+    Deprecated2 = 14,
+}
+
+#[derive(Debug, TryFromPrimitive)]
+#[repr(u8)]
+pub enum DllStorageClass {
+    Default = 0,
+    Import = 1,
+    Export = 2,
+}
+
+#[derive(Debug, TryFromPrimitive)]
+#[repr(u8)]
+pub enum CallConv {
+    C = 0,
+    Fast = 8,
+    Cold = 9,
+    GHC = 10,
+    HiPE = 11,
+    AnyReg = 13,
+    PreserveMost = 14,
+    PreserveAll = 15,
+    Swift = 16,
+    /// CXX_FAST_TLS
+    CxxFastTls = 17,
+    Tail = 18,
+    /// CFGuard_Check
+    CFGuardCheck = 19,
+    SwiftTail = 20,
+    PreserveNone = 21,
+    /// X86_StdCall (first target cc)
+    X86StdCall = 64,
+    /// X86_FastCall
+    X86FastCall = 65,
+    /// ARM_APCS
+    ArmApcs = 66,
+    /// ARM_AAPCS
+    ArmAapcs = 67,
+    /// ARM_AAPCS_VFP
+    ArmAapcsVfp = 68,
+    /// MSP430_INTR
+    Msp430Intr = 69,
+    /// X86_ThisCall
+    X86ThisCall = 70,
+    /// PTX_Kernel
+    PTXKernel = 71,
+    /// PTX_Device
+    PTXDevice = 72,
+    /// SPIR_FUNC
+    SpirFunc = 75,
+    /// SPIR_KERNEL
+    SpirKernel = 76,
+    /// Intel_OCL_BI
+    IntelOclBi = 77,
+    /// X86_64_SysV
+    X8664SysV = 78,
+    /// Win64
+    Win64 = 79,
+    /// X86_VectorCall
+    X86VectorCall = 80,
+    /// DUMMY_HHVM
+    DummyHhvm = 81,
+    /// DUMMY_HHVM_C
+    DummyHhvmC = 82,
+    /// X86_INTR
+    X86Intr = 83,
+    /// AVR_INTR
+    AvrIntr = 84,
+    /// AVR_SIGNAL
+    AvrSignal = 85,
+    /// AVR_BUILTIN
+    AvrBuiltin = 86,
+    /// AMDGPU_VS
+    AmdGpuVs = 87,
+    /// AMDGPU_GS
+    AmdGpuGs = 88,
+    /// AMDGPU_PS
+    AmdGpuPs = 89,
+    /// AMDGPU_CS
+    AmdGpuCs = 90,
+    /// AMDGPU_KERNEL
+    AmdGpuKernel = 91,
+    /// X86_RegCall
+    X86RegCall = 92,
+    /// AMDGPU_HS
+    AmdGpuHs = 93,
+    /// MSP430_BUILTIN
+    Msp430Builtin = 94,
+    /// AMDGPU_LS
+    AmdGpuLs = 95,
+    /// AMDGPU_ES
+    AmdGpuEs = 96,
+    /// AArch64_VectorCall
+    AArch64VectorCall = 97,
+    /// AArch64_SVE_VectorCall
+    AArch64SVEVectorCall = 98,
+    /// WASM_EmscriptenInvoke
+    WasmEmscriptenInvoke = 99,
+    /// AMDGPU_Gfx
+    AmdGpuGfx = 100,
+    /// M68k_INTR
+    M68kIntr = 101,
+    AArch64SmeAbiSupportRoutinesPreserveMostFromX0 = 102,
+    AArch64SmeAbiSupportRoutinesPreserveMostFromX2 = 103,
+    AmdGpuCSChain = 104,
+    AmdGpuCSChainPreserve = 105,
+    M68kRTD = 106,
+    Graal = 107,
+    Arm64ECThunkX64 = 108,
+    Arm64ECThunkNative = 109,
+    RiscVVectorCall = 110,
+    AArch64SmeAbiSupportRoutinesPreserveMostFromX1 = 111,
+}
+
+/// call conv field in bitcode is often mixed with flags
+impl CallConv {
+    pub fn from_flags(ccinfo_flags: u64) -> Result<Self, String> {
+        // static_cast<CallingConv::ID>((0x7ff & CCInfo) >> bitc::CALL_CCONV));
+        let id = u8::try_from((ccinfo_flags & 0x7ff) >> 1).map_err(|e| e.to_string())?;
+        Self::try_from_primitive(id).map_err(|e| e.to_string())
+    }
+}
+
+/// BinaryOpcodes - These are values used in the bitcode files to encode which
+/// binop a CST_CODE_CE_BINOP or a XXX refers to.  The values of these enums
+/// have no fixed relation to the LLVM IR enum values.  Changing these will
+/// break compatibility with old files.
+#[derive(Debug, TryFromPrimitive)]
+#[repr(u8)]
+pub enum BinOpcode {
+    Add = 0,
+    Sub = 1,
+    Mul = 2,
+    Udiv = 3,
+    Sdiv = 4, // overloaded for FP
+    Urem = 5,
+    Srem = 6, // overloaded for FP
+    Shl = 7,
+    Lshr = 8,
+    Ashr = 9,
+    And = 10,
+    Or = 11,
+    Xor = 12,
+}
+
+/// Encoded AtomicOrdering values.
+#[derive(Debug, TryFromPrimitive, Default)]
+#[repr(u8)]
+pub enum AtomicOrdering {
+    #[default]
+    Notatomic = 0,
+    Unordered = 1,
+    Monotonic = 2,
+    Acquire = 3,
+    Release = 4,
+    AcqRel = 5,
+    SeqCst = 6,
+}
+
+/// COMDATSELECTIONKIND enumerates the possible selection mechanisms for
+/// COMDAT sections.
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+pub enum ComdatSelectionKind {
+    Any = 1,
+    ExactMatch = 2,
+    Largest = 3,
+    NoDuplicates = 4,
+    SameSize = 5,
+}
+
+/// Atomic read-modify-write operations
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum RmwOperation {
+    /// `XCHG`
+    Xchg = 0,
+
+    /// `ADD`
+    Add = 1,
+
+    /// `SUB`
+    Sub = 2,
+
+    /// `AND`
+    And = 3,
+
+    /// `NAND`
+    Nand = 4,
+
+    /// `OR`
+    Or = 5,
+
+    /// `XOR`
+    Xor = 6,
+
+    /// `MAX`
+    Max = 7,
+
+    /// `MIN`
+    Min = 8,
+
+    /// `UMAX`
+    Umax = 9,
+
+    /// `UMIN`
+    Umin = 10,
+
+    /// `FADD`
+    Fadd = 11,
+
+    /// `FSUB`
+    Fsub = 12,
+
+    /// `FMAX`
+    Fmax = 13,
+
+    /// `FMIN`
+    Fmin = 14,
+
+    /// `UINC_WRAP`
+    UincWrap = 15,
+
+    /// `UDEC_WRAP`
+    UdecWrap = 16,
+
+    /// `USUB_COND`
+    UsSubCond = 17,
+
+    /// `USUB_SAT`
+    UsSubSat = 18,
+}
+
+/// Unary Opcodes
+#[derive(Debug, Clone, Copy, TryFromPrimitive)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum UnaryOpcode {
+    /// `UNOP_FNEG`
+    Fneg = 0,
+}

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -10,18 +10,18 @@ pub trait BitStreamVisitor {
 
     /// Called when a new block is encountered. Return `true` to enter the block
     /// and read its contents, or `false` to skip it.
-    fn should_enter_block(&mut self, block_id: u64) -> bool;
+    fn should_enter_block(&mut self, block_id: u32) -> bool;
 
     /// Called when a block is exited.
-    fn did_exit_block(&mut self, block_id: u64);
+    fn did_exit_block(&mut self, block_id: u32);
 
     /// Called whenever a record is encountered.
-    fn visit(&mut self, block_id: u64, record: Record);
+    fn visit(&mut self, block_id: u32, record: Record);
 }
 
 /// A basic visitor that collects all the blocks and records in a stream.
 pub struct CollectingVisitor {
-    stack: Vec<(u64, Vec<BitcodeElement>)>,
+    stack: Vec<(u32, Vec<BitcodeElement>)>,
 }
 
 impl CollectingVisitor {
@@ -40,12 +40,12 @@ impl CollectingVisitor {
 }
 
 impl BitStreamVisitor for CollectingVisitor {
-    fn should_enter_block(&mut self, id: u64) -> bool {
+    fn should_enter_block(&mut self, id: u32) -> bool {
         self.stack.push((id, Vec::new()));
         true
     }
 
-    fn did_exit_block(&mut self, block_id: u64) {
+    fn did_exit_block(&mut self, block_id: u32) {
         if let Some((id, elements)) = self.stack.pop() {
             assert_eq!(id, block_id);
             let block = Block { id, elements };
@@ -54,7 +54,7 @@ impl BitStreamVisitor for CollectingVisitor {
         }
     }
 
-    fn visit(&mut self, _block_id: u64, record: Record) {
+    fn visit(&mut self, _block_id: u32, record: Record) {
         let last = self.stack.last_mut().unwrap();
         last.1.push(BitcodeElement::Record(record));
     }

--- a/tests/test_bitcode_reader.rs
+++ b/tests/test_bitcode_reader.rs
@@ -44,16 +44,16 @@ fn test_bitstream_reader() {
     struct LoggingVisitor(Vec<String>);
 
     impl BitStreamVisitor for LoggingVisitor {
-        fn should_enter_block(&mut self, id: u64) -> bool {
+        fn should_enter_block(&mut self, id: u32) -> bool {
             self.0.push(format!("entering block: {id}"));
             true
         }
 
-        fn did_exit_block(&mut self, id: u64) {
+        fn did_exit_block(&mut self, id: u32) {
             self.0.push(format!("exiting block: {id}"));
         }
 
-        fn visit(&mut self, _block_id: u64, mut record: Record) {
+        fn visit(&mut self, _block_id: u32, mut record: Record) {
             let payload = if let Some(payload) = record.take_payload() {
                 match payload {
                     Payload::Array(ele) => format!("array({} elements)", ele.len()),
@@ -152,15 +152,15 @@ fn test_block_skip() {
     struct No15(usize);
 
     impl BitStreamVisitor for No15 {
-        fn should_enter_block(&mut self, id: u64) -> bool {
+        fn should_enter_block(&mut self, id: u32) -> bool {
             id != 15
         }
 
-        fn did_exit_block(&mut self, id: u64) {
+        fn did_exit_block(&mut self, id: u32) {
             assert_ne!(15, id);
         }
 
-        fn visit(&mut self, block_id: u64, _: Record) {
+        fn visit(&mut self, block_id: u32, _: Record) {
             assert_ne!(15, block_id);
             self.0 += 1;
         }


### PR DESCRIPTION
My goal is to parse all the instructions and basic blocks, and that's where I'm at: 

https://github.com/kornelski/tmp-pr-llvmir/blob/more-more/examples/parse_records.rs (This isn't a complete file, I've cut out the most embarrassingly unfinished parts.)

The super annoying thing about instruction parsing is that their schema is completely ad-hoc. The comments in LLVM headers are a gross oversimplification of the records, and the official docs are woefully incomplete. Every instruction is encoded in a slightly different way, with clever tricks to save a few bits here and there, and with scars of from the format's evolution.

Translating it back to a coherent usable schema is a total drudgery. I've even tried AI assistants to do the boring work, but they systematically overlook important details and exceptions, so it only wasted more of my time on debugging that.

The hardest part is that IDs that instructions depend on are encoded in an overly clever implementation-dependent way. They are relative to the current length of LLVM's `Value` table. LLVM modifies this table is many places, and it's a concatenation of global and function-local tables. If I don't reconstruct the full tables exactly like LLVM does, then Value IDs get out of sync, and when they are out of sync then `valueAndType` encoding reads a wrong number of records without any way to detect the error, and then all other fields get out of sync, and it snowballs from there into garbage.

Unfortunately, the value table is updated in LLVM conditionally when it encounters a "non-void" value. IR instructions are values, and have types. This means that to parse the bitcode, it's necessary to understand *all records for all instructions*, including all the variations of their encodings, and effectively parse all of their fields, in order to be able to extract their types correctly to check them for void-ness. It's not possible to parse just a subset of instructions and their interesting fields.

Because in LLVM the IR instructions are subclasses of the `Value` class, there isn't even a straightforward mapping between `type` fields in the bitcode to the LLVM's idea of the type of the instruction! It depends what each C++ constructor of each `Instruction` subclass ends up putting in the the `TypeID` field, or in the `getType` getter. Those IDs are different from the IDs in the bitcode, and they go through layers of indirection for compound and SIMD types. Certain instructions that have their own hardcoded type, even when their bitcode record has a type field.

I got to the point where I can parse all the relevant blocks, and all of the instructions that the current versions of LLVM typically produce. But something somewhere doesn't get the `ValueID` tracking 100% correctly, and the decoding gets out of sync in non-trivial functions. This is incredibly hard to track down, because an incorrect update of the value table doesn't cause problems immediately. The IDs get out of sync later much later, when the number of instructions exceeds the number of values. Even then, it's not a detectable error, because immediately it only causes reading a value from the global table instead of the function-local table or vice versa. Once Value IDs are out of sync, it causes reading a wrong number of fields in some of the properties of some of the instructions. Even then, many instructions can't detect getting bad data, because most have optional fields at the end, so there's no way to know when a record ends up shorter than expected.

I've even tried instrumenting LLVM itself and comparing what it reads with what my implementation reads, but LLVM doesn't read the bitcode in the same order it is in the file. It "materializes" functions lazily and jumps around the file as needed. Additionally it immediately translates bitcode records into internal C++ objects, so the IDs get translated to pointers or runtime lookup tables that use different numbering scheme, so what LLVM returns from the parser ends up being impossible to compare with the original.
